### PR TITLE
Add NONE transport type to send SPDM without a transport layer

### DIFF
--- a/spdm_emu/spdm_emu_common/command.h
+++ b/spdm_emu/spdm_emu_common/command.h
@@ -17,6 +17,7 @@
 //   payload (SPDM message, starting from SPDM_HEADER): PayloadSize (little endian)
 //
 
+#define SOCKET_TRANSPORT_TYPE_NONE 0x00
 #define SOCKET_TRANSPORT_TYPE_MCTP 0x01
 #define SOCKET_TRANSPORT_TYPE_PCI_DOE 0x02
 

--- a/spdm_emu/spdm_emu_common/spdm_emu.c
+++ b/spdm_emu/spdm_emu_common/spdm_emu.c
@@ -24,7 +24,7 @@ uint32 m_exe_session =
 
 void print_usage(IN char8 *name)
 {
-	printf("\n%s [--trans MCTP|PCI_DOE]\n", name);
+	printf("\n%s [--trans MCTP|PCI_DOE|NONE]\n", name);
 	printf("   [--ver 1.0|1.1]\n");
 	printf("   [--sec_ver 0|1.1]\n");
 	printf("   [--cap CACHE|CERT|CHAL|MEAS_NO_SIG|MEAS_SIG|MEAS_FRESH|ENCRYPT|MAC|MUT_AUTH|KEY_EX|PSK|PSK_WITH_CONTEXT|ENCAP|HBEAT|KEY_UPD|HANDSHAKE_IN_CLEAR|PUB_KEY_ID]\n");
@@ -112,6 +112,7 @@ typedef struct {
 } value_string_entry_t;
 
 value_string_entry_t m_transport_value_string_table[] = {
+	{ SOCKET_TRANSPORT_TYPE_NONE, "NONE"},
 	{ SOCKET_TRANSPORT_TYPE_MCTP, "MCTP" },
 	{ SOCKET_TRANSPORT_TYPE_PCI_DOE, "PCI_DOE" },
 };

--- a/spdm_emu/spdm_requester_emu/CMakeLists.txt
+++ b/spdm_emu/spdm_requester_emu/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 2.6)
 
 INCLUDE_DIRECTORIES(${PROJECT_SOURCE_DIR}/spdm_emu/spdm_requester_emu
                     ${PROJECT_SOURCE_DIR}/spdm_emu/spdm_emu_common
+                    ${PROJECT_SOURCE_DIR}/spdm_emu/spdm_transport_none_lib
                     ${LIBSPDM_DIR}/os_stub/spdm_device_secret_lib
                     ${LIBSPDM_DIR}/include
                     ${LIBSPDM_DIR}/include/hal
@@ -21,6 +22,8 @@ SET(src_spdm_requester_emu
     ${PROJECT_SOURCE_DIR}/spdm_emu/spdm_emu_common/nv_storage.c
     ${PROJECT_SOURCE_DIR}/spdm_emu/spdm_emu_common/pcap.c
     ${PROJECT_SOURCE_DIR}/spdm_emu/spdm_emu_common/support.c
+    ${PROJECT_SOURCE_DIR}/spdm_emu/spdm_transport_none_lib/common.c
+    ${PROJECT_SOURCE_DIR}/spdm_emu/spdm_transport_none_lib/none.c
 )
 
 SET(spdm_requester_emu_LIBRARY

--- a/spdm_emu/spdm_requester_emu/spdm_requester.c
+++ b/spdm_emu/spdm_requester_emu/spdm_requester.c
@@ -125,6 +125,10 @@ void *spdm_client_init(void)
 		spdm_register_transport_layer_func(
 			spdm_context, spdm_transport_pci_doe_encode_message,
 			spdm_transport_pci_doe_decode_message);
+	} else if (m_use_transport_layer == SOCKET_TRANSPORT_TYPE_NONE) {
+		spdm_register_transport_layer_func(
+			spdm_context, spdm_transport_none_encode_message,
+			spdm_transport_none_decode_message);
 	} else {
 		return NULL;
 	}

--- a/spdm_emu/spdm_requester_emu/spdm_requester_emu.c
+++ b/spdm_emu/spdm_requester_emu/spdm_requester_emu.c
@@ -110,14 +110,17 @@ boolean platform_client_routine(IN uint16 port_number)
 
 	m_socket = platform_socket;
 
-	response_size = sizeof(m_receive_buffer);
-	result = communicate_platform_data(platform_socket,
-					   SOCKET_SPDM_COMMAND_TEST,
-					   (uint8 *)"Client Hello!",
-					   sizeof("Client Hello!"), &response,
-					   &response_size, m_receive_buffer);
-	if (!result) {
-		goto done;
+	if (m_use_transport_layer != SOCKET_TRANSPORT_TYPE_NONE) {
+		response_size = sizeof(m_receive_buffer);
+		result = communicate_platform_data(
+			platform_socket,
+			SOCKET_SPDM_COMMAND_TEST,
+			(uint8 *)"Client Hello!",
+			sizeof("Client Hello!"), &response,
+			&response_size, m_receive_buffer);
+		if (!result) {
+			goto done;
+		}
 	}
 
 	if (m_use_transport_layer == SOCKET_TRANSPORT_TYPE_PCI_DOE) {

--- a/spdm_emu/spdm_requester_emu/spdm_requester_emu.h
+++ b/spdm_emu/spdm_requester_emu/spdm_requester_emu.h
@@ -10,6 +10,7 @@
 #include <base.h>
 #include <library/memlib.h>
 #include <library/spdm_requester_lib.h>
+#include <spdm_transport_none_lib.h>
 #include <library/spdm_transport_mctp_lib.h>
 #include <library/spdm_transport_pcidoe_lib.h>
 

--- a/spdm_emu/spdm_responder_emu/CMakeLists.txt
+++ b/spdm_emu/spdm_responder_emu/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 2.6)
 
 INCLUDE_DIRECTORIES(${PROJECT_SOURCE_DIR}/spdm_emu/spdm_responder_emu
                     ${PROJECT_SOURCE_DIR}/spdm_emu/spdm_emu_common
+                    ${PROJECT_SOURCE_DIR}/spdm_emu/spdm_transport_none_lib
                     ${LIBSPDM_DIR}/os_stub/spdm_device_secret_lib
                     ${LIBSPDM_DIR}/include
                     ${LIBSPDM_DIR}/include/hal
@@ -19,6 +20,8 @@ SET(src_spdm_responder_emu
     ${PROJECT_SOURCE_DIR}/spdm_emu/spdm_emu_common/nv_storage.c
     ${PROJECT_SOURCE_DIR}/spdm_emu/spdm_emu_common/pcap.c
     ${PROJECT_SOURCE_DIR}/spdm_emu/spdm_emu_common/support.c
+    ${PROJECT_SOURCE_DIR}/spdm_emu/spdm_transport_none_lib/common.c
+    ${PROJECT_SOURCE_DIR}/spdm_emu/spdm_transport_none_lib/none.c
 )
 
 SET(spdm_responder_emu_LIBRARY

--- a/spdm_emu/spdm_responder_emu/spdm_responder.c
+++ b/spdm_emu/spdm_responder_emu/spdm_responder.c
@@ -127,6 +127,10 @@ void *spdm_server_init(void)
 		spdm_register_transport_layer_func(
 			spdm_context, spdm_transport_pci_doe_encode_message,
 			spdm_transport_pci_doe_decode_message);
+	} else if (m_use_transport_layer == SOCKET_TRANSPORT_TYPE_NONE) {
+		spdm_register_transport_layer_func(
+			spdm_context, spdm_transport_none_encode_message,
+			spdm_transport_none_decode_message);
 	} else {
 		return NULL;
 	}

--- a/spdm_emu/spdm_responder_emu/spdm_responder_emu.h
+++ b/spdm_emu/spdm_responder_emu/spdm_responder_emu.h
@@ -10,6 +10,7 @@
 #include <base.h>
 #include <library/memlib.h>
 #include <library/spdm_responder_lib.h>
+#include <spdm_transport_none_lib.h>
 #include <library/spdm_transport_mctp_lib.h>
 #include <library/spdm_transport_pcidoe_lib.h>
 

--- a/spdm_emu/spdm_transport_none_lib/common.c
+++ b/spdm_emu/spdm_transport_none_lib/common.c
@@ -1,0 +1,342 @@
+/**
+    Copyright Notice:
+    Copyright 2021 DMTF, Componolit. All rights reserved.
+    License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
+**/
+
+#include <spdm_transport_none_lib.h>
+#include <library/spdm_secured_message_lib.h>
+
+/**
+  Encode a normal message or secured message to a transport message.
+
+  @param  session_id                    Indicates if it is a secured message protected via SPDM session.
+                                       If session_id is NULL, it is a normal message.
+                                       If session_id is NOT NULL, it is a secured message.
+  @param  message_size                  size in bytes of the message data buffer.
+  @param  message                      A pointer to a source buffer to store the message.
+  @param  transport_message_size         size in bytes of the transport message data buffer.
+  @param  transport_message             A pointer to a destination buffer to store the transport message.
+
+  @retval RETURN_SUCCESS               The message is encoded successfully.
+  @retval RETURN_INVALID_PARAMETER     The message is NULL or the message_size is zero.
+**/
+return_status none_encode_message(IN uint32 *session_id, IN uintn message_size,
+				  IN void *message,
+				  IN OUT uintn *transport_message_size,
+				  OUT void *transport_message);
+
+/**
+  Decode a transport message to a normal message or secured message.
+
+  @param  session_id                    Indicates if it is a secured message protected via SPDM session.
+                                       If *session_id is NULL, it is a normal message.
+                                       If *session_id is NOT NULL, it is a secured message.
+  @param  transport_message_size         size in bytes of the transport message data buffer.
+  @param  transport_message             A pointer to a source buffer to store the transport message.
+  @param  message_size                  size in bytes of the message data buffer.
+  @param  message                      A pointer to a destination buffer to store the message.
+  @retval RETURN_SUCCESS               The message is encoded successfully.
+  @retval RETURN_INVALID_PARAMETER     The message is NULL or the message_size is zero.
+**/
+return_status none_decode_message(OUT uint32 **session_id,
+				  IN uintn transport_message_size,
+				  IN void *transport_message,
+				  IN OUT uintn *message_size,
+				  OUT void *message);
+
+/**
+  Encode a normal message or secured message to a transport message.
+
+  @param  session_id                    Indicates if it is a secured message protected via SPDM session.
+                                       If session_id is NULL, it is a normal message.
+                                       If session_id is NOT NULL, it is a secured message.
+  @param  message_size                  size in bytes of the message data buffer.
+  @param  message                      A pointer to a source buffer to store the message.
+  @param  transport_message_size         size in bytes of the transport message data buffer.
+  @param  transport_message             A pointer to a destination buffer to store the transport message.
+
+  @retval RETURN_SUCCESS               The message is encoded successfully.
+  @retval RETURN_INVALID_PARAMETER     The message is NULL or the message_size is zero.
+**/
+typedef return_status (*transport_encode_message_func)(
+	IN uint32 *session_id, IN uintn message_size, IN void *message,
+	IN OUT uintn *transport_message_size, OUT void *transport_message);
+
+/**
+  Decode a transport message to a normal message or secured message.
+
+  @param  session_id                    Indicates if it is a secured message protected via SPDM session.
+                                       If *session_id is NULL, it is a normal message.
+                                       If *session_id is NOT NULL, it is a secured message.
+  @param  transport_message_size         size in bytes of the transport message data buffer.
+  @param  transport_message             A pointer to a source buffer to store the transport message.
+  @param  message_size                  size in bytes of the message data buffer.
+  @param  message                      A pointer to a destination buffer to store the message.
+  @retval RETURN_SUCCESS               The message is encoded successfully.
+  @retval RETURN_INVALID_PARAMETER     The message is NULL or the message_size is zero.
+**/
+typedef return_status (*transport_decode_message_func)(
+	OUT uint32 **session_id, IN uintn transport_message_size,
+	IN void *transport_message, IN OUT uintn *message_size,
+	OUT void *message);
+
+/**
+  Encode an SPDM or APP message to a transport layer message.
+
+  For normal SPDM message, it adds the transport layer wrapper.
+  For secured SPDM message, it encrypts a secured message then adds the transport layer wrapper.
+  For secured APP message, it encrypts a secured message then adds the transport layer wrapper.
+
+  The APP message is encoded to a secured message directly in SPDM session.
+  The APP message format is defined by the transport layer.
+  Take MCTP as example: APP message == MCTP header (MCTP_MESSAGE_TYPE_SPDM) + SPDM message
+
+  @param  spdm_context                  A pointer to the SPDM context.
+  @param  session_id                    Indicates if it is a secured message protected via SPDM session.
+                                       If session_id is NULL, it is a normal message.
+                                       If session_id is NOT NULL, it is a secured message.
+  @param  is_app_message                 Indicates if it is an APP message or SPDM message.
+  @param  is_requester                  Indicates if it is a requester message.
+  @param  message_size                  size in bytes of the message data buffer.
+  @param  message                      A pointer to a source buffer to store the message.
+  @param  transport_message_size         size in bytes of the transport message data buffer.
+  @param  transport_message             A pointer to a destination buffer to store the transport message.
+
+  @retval RETURN_SUCCESS               The message is encoded successfully.
+  @retval RETURN_INVALID_PARAMETER     The message is NULL or the message_size is zero.
+**/
+return_status spdm_transport_none_encode_message(
+	IN void *spdm_context, IN uint32 *session_id, IN boolean is_app_message,
+	IN boolean is_requester, IN uintn message_size, IN void *message,
+	IN OUT uintn *transport_message_size, OUT void *transport_message)
+{
+	return_status status;
+	transport_encode_message_func transport_encode_message;
+	uint8 app_message_buffer[MAX_SPDM_MESSAGE_BUFFER_SIZE];
+	void *app_message;
+	uintn app_message_size;
+	uint8 secured_message[MAX_SPDM_MESSAGE_BUFFER_SIZE];
+	uintn secured_message_size;
+	spdm_secured_message_callbacks_t spdm_secured_message_callbacks_t;
+	void *secured_message_context;
+
+	spdm_secured_message_callbacks_t.version =
+		SPDM_SECURED_MESSAGE_CALLBACKS_VERSION;
+	spdm_secured_message_callbacks_t.get_sequence_number =
+		spdm_none_get_sequence_number;
+	spdm_secured_message_callbacks_t.get_max_random_number_count =
+		spdm_none_get_max_random_number_count;
+
+	if (is_app_message && (session_id == NULL)) {
+		return RETURN_UNSUPPORTED;
+	}
+
+	transport_encode_message = none_encode_message;
+	if (session_id != NULL) {
+		secured_message_context =
+			spdm_get_secured_message_context_via_session_id(
+				spdm_context, *session_id);
+		if (secured_message_context == NULL) {
+			return RETURN_UNSUPPORTED;
+		}
+
+		if (!is_app_message) {
+			// SPDM message to APP message
+			app_message = app_message_buffer;
+			app_message_size = sizeof(app_message_buffer);
+			status = transport_encode_message(NULL, message_size,
+							  message,
+							  &app_message_size,
+							  app_message_buffer);
+			if (RETURN_ERROR(status)) {
+				DEBUG((DEBUG_ERROR,
+				       "transport_encode_message - %p\n",
+				       status));
+				return RETURN_UNSUPPORTED;
+			}
+		} else {
+			app_message = message;
+			app_message_size = message_size;
+		}
+		// APP message to secured message
+		secured_message_size = sizeof(secured_message);
+		status = spdm_encode_secured_message(
+			secured_message_context, *session_id, is_requester,
+			app_message_size, app_message, &secured_message_size,
+			secured_message, &spdm_secured_message_callbacks_t);
+		if (RETURN_ERROR(status)) {
+			DEBUG((DEBUG_ERROR,
+			       "spdm_encode_secured_message - %p\n", status));
+			return status;
+		}
+
+		// secured message to secured MCTP message
+		status = transport_encode_message(
+			session_id, secured_message_size, secured_message,
+			transport_message_size, transport_message);
+		if (RETURN_ERROR(status)) {
+			DEBUG((DEBUG_ERROR, "transport_encode_message - %p\n",
+			       status));
+			return RETURN_UNSUPPORTED;
+		}
+	} else {
+		// SPDM message to normal MCTP message
+		status = transport_encode_message(NULL, message_size, message,
+						  transport_message_size,
+						  transport_message);
+		if (RETURN_ERROR(status)) {
+			DEBUG((DEBUG_ERROR, "transport_encode_message - %p\n",
+			       status));
+			return RETURN_UNSUPPORTED;
+		}
+	}
+
+	return RETURN_SUCCESS;
+}
+
+/**
+  Decode an SPDM or APP message from a transport layer message.
+
+  For normal SPDM message, it removes the transport layer wrapper,
+  For secured SPDM message, it removes the transport layer wrapper, then decrypts and verifies a secured message.
+  For secured APP message, it removes the transport layer wrapper, then decrypts and verifies a secured message.
+
+  The APP message is decoded from a secured message directly in SPDM session.
+  The APP message format is defined by the transport layer.
+  Take MCTP as example: APP message == MCTP header (MCTP_MESSAGE_TYPE_SPDM) + SPDM message
+
+  @param  spdm_context                  A pointer to the SPDM context.
+  @param  session_id                    Indicates if it is a secured message protected via SPDM session.
+                                       If *session_id is NULL, it is a normal message.
+                                       If *session_id is NOT NULL, it is a secured message.
+  @param  is_app_message                 Indicates if it is an APP message or SPDM message.
+  @param  is_requester                  Indicates if it is a requester message.
+  @param  transport_message_size         size in bytes of the transport message data buffer.
+  @param  transport_message             A pointer to a source buffer to store the transport message.
+  @param  message_size                  size in bytes of the message data buffer.
+  @param  message                      A pointer to a destination buffer to store the message.
+
+  @retval RETURN_SUCCESS               The message is decoded successfully.
+  @retval RETURN_INVALID_PARAMETER     The message is NULL or the message_size is zero.
+  @retval RETURN_UNSUPPORTED           The transport_message is unsupported.
+**/
+return_status spdm_transport_none_decode_message(
+	IN void *spdm_context, OUT uint32 **session_id,
+	OUT boolean *is_app_message, IN boolean is_requester,
+	IN uintn transport_message_size, IN void *transport_message,
+	IN OUT uintn *message_size, OUT void *message)
+{
+	return_status status;
+	transport_decode_message_func transport_decode_message;
+	uint32 *SecuredMessageSessionId;
+	uint8 secured_message[MAX_SPDM_MESSAGE_BUFFER_SIZE];
+	uintn secured_message_size;
+	uint8 app_message[MAX_SPDM_MESSAGE_BUFFER_SIZE];
+	uintn app_message_size;
+	spdm_secured_message_callbacks_t spdm_secured_message_callbacks_t;
+	void *secured_message_context;
+	spdm_error_struct_t spdm_error;
+
+	spdm_error.error_code = 0;
+	spdm_error.session_id = 0;
+	spdm_set_last_spdm_error_struct(spdm_context, &spdm_error);
+
+	spdm_secured_message_callbacks_t.version =
+		SPDM_SECURED_MESSAGE_CALLBACKS_VERSION;
+	spdm_secured_message_callbacks_t.get_sequence_number =
+		spdm_none_get_sequence_number;
+	spdm_secured_message_callbacks_t.get_max_random_number_count =
+		spdm_none_get_max_random_number_count;
+
+	if ((session_id == NULL) || (is_app_message == NULL)) {
+		return RETURN_UNSUPPORTED;
+	}
+
+	transport_decode_message = none_decode_message;
+
+	SecuredMessageSessionId = NULL;
+	// Detect received message
+	secured_message_size = sizeof(secured_message);
+	status = transport_decode_message(
+		&SecuredMessageSessionId, transport_message_size,
+		transport_message, &secured_message_size, secured_message);
+	if (RETURN_ERROR(status)) {
+		DEBUG((DEBUG_ERROR, "transport_decode_message - %p\n", status));
+		return RETURN_UNSUPPORTED;
+	}
+
+	if (SecuredMessageSessionId != NULL) {
+		*session_id = SecuredMessageSessionId;
+
+		secured_message_context =
+			spdm_get_secured_message_context_via_session_id(
+				spdm_context, *SecuredMessageSessionId);
+		if (secured_message_context == NULL) {
+			spdm_error.error_code = SPDM_ERROR_CODE_INVALID_SESSION;
+			spdm_error.session_id = *SecuredMessageSessionId;
+			spdm_set_last_spdm_error_struct(spdm_context,
+							&spdm_error);
+			return RETURN_UNSUPPORTED;
+		}
+
+		// Secured message to APP message
+		app_message_size = sizeof(app_message);
+		status = spdm_decode_secured_message(
+			secured_message_context, *SecuredMessageSessionId,
+			is_requester, secured_message_size, secured_message,
+			&app_message_size, app_message,
+			&spdm_secured_message_callbacks_t);
+		if (RETURN_ERROR(status)) {
+			DEBUG((DEBUG_ERROR,
+			       "spdm_decode_secured_message - %p\n", status));
+			spdm_secured_message_get_last_spdm_error_struct(
+				secured_message_context, &spdm_error);
+			spdm_set_last_spdm_error_struct(spdm_context,
+							&spdm_error);
+			return RETURN_UNSUPPORTED;
+		}
+
+		// APP message to SPDM message.
+		status = transport_decode_message(&SecuredMessageSessionId,
+						  app_message_size, app_message,
+						  message_size, message);
+		if (RETURN_ERROR(status)) {
+			*is_app_message = TRUE;
+			// just return APP message.
+			if (*message_size < app_message_size) {
+				*message_size = app_message_size;
+				return RETURN_BUFFER_TOO_SMALL;
+			}
+			*message_size = app_message_size;
+			copy_mem(message, app_message, *message_size);
+			return RETURN_SUCCESS;
+		} else {
+			*is_app_message = FALSE;
+			if (SecuredMessageSessionId == NULL) {
+				return RETURN_SUCCESS;
+			} else {
+				// get encapsulated secured message - cannot handle it.
+				DEBUG((DEBUG_ERROR,
+				       "transport_decode_message - expect encapsulated normal but got session (%08x)\n",
+				       *SecuredMessageSessionId));
+				return RETURN_UNSUPPORTED;
+			}
+		}
+	} else {
+		// get non-secured message
+		status = transport_decode_message(&SecuredMessageSessionId,
+						  transport_message_size,
+						  transport_message,
+						  message_size, message);
+		if (RETURN_ERROR(status)) {
+			DEBUG((DEBUG_ERROR, "transport_decode_message - %p\n",
+			       status));
+			return RETURN_UNSUPPORTED;
+		}
+		ASSERT(SecuredMessageSessionId == NULL);
+		*session_id = NULL;
+		*is_app_message = FALSE;
+		return RETURN_SUCCESS;
+	}
+}

--- a/spdm_emu/spdm_transport_none_lib/none.c
+++ b/spdm_emu/spdm_transport_none_lib/none.c
@@ -1,0 +1,88 @@
+/**
+    Copyright Notice:
+    Copyright 2021 DMTF. All rights reserved.
+    License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
+**/
+
+#include <spdm_transport_none_lib.h>
+
+/**
+  Encode a normal message or secured message to a transport message.
+
+  @param  session_id                    Indicates if it is a secured message protected via SPDM session.
+                                       If session_id is NULL, it is a normal message.
+                                       If session_id is NOT NULL, it is a secured message.
+  @param  message_size                  size in bytes of the message data buffer.
+  @param  message                      A pointer to a source buffer to store the message.
+  @param  transport_message_size         size in bytes of the transport message data buffer.
+  @param  transport_message             A pointer to a destination buffer to store the transport message.
+
+  @retval RETURN_SUCCESS               The message is encoded successfully.
+  @retval RETURN_INVALID_PARAMETER     The message is NULL or the message_size is zero.
+**/
+return_status none_encode_message(IN uint32 *session_id, IN uintn message_size,
+				  IN void *message,
+				  IN OUT uintn *transport_message_size,
+				  OUT void *transport_message)
+{
+    *transport_message_size = message_size;
+    copy_mem((uint8 *)transport_message, message, message_size);
+    zero_mem((uint8 *)transport_message + message_size,
+             *transport_message_size - message_size);
+    return RETURN_SUCCESS;
+}
+
+/**
+  Decode a transport message to a normal message or secured message.
+
+  @param  session_id                    Indicates if it is a secured message protected via SPDM session.
+                                       If *session_id is NULL, it is a normal message.
+                                       If *session_id is NOT NULL, it is a secured message.
+  @param  transport_message_size         size in bytes of the transport message data buffer.
+  @param  transport_message             A pointer to a source buffer to store the transport message.
+  @param  message_size                  size in bytes of the message data buffer.
+  @param  message                      A pointer to a destination buffer to store the message.
+  @retval RETURN_SUCCESS               The message is encoded successfully.
+  @retval RETURN_INVALID_PARAMETER     The message is NULL or the message_size is zero.
+**/
+return_status none_decode_message(OUT uint32 **session_id,
+				  IN uintn transport_message_size,
+				  IN void *transport_message,
+				  IN OUT uintn *message_size, OUT void *message)
+{
+    *message_size = transport_message_size;
+    copy_mem(message, transport_message, transport_message_size);
+    return RETURN_SUCCESS;
+}
+
+/**
+  Get sequence number in an SPDM secure message.
+
+  This value is transport layer specific.
+
+  @param sequence_number        The current sequence number used to encode or decode message.
+  @param sequence_number_buffer  A buffer to hold the sequence number output used in the secured message.
+                               The size in byte of the output buffer shall be 8.
+
+  @return size in byte of the sequence_number_buffer.
+          It shall be no greater than 8.
+          0 means no sequence number is required.
+**/
+uint8 spdm_none_get_sequence_number(IN uint64 sequence_number,
+				    IN OUT uint8 *sequence_number_buffer)
+{
+    return 0;
+}
+
+/**
+  Return max random number count in an SPDM secure message.
+
+  This value is transport layer specific.
+
+  @return Max random number count in an SPDM secured message.
+          0 means no randum number is required.
+**/
+uint32 spdm_none_get_max_random_number_count(void)
+{
+	return 0;
+}

--- a/spdm_emu/spdm_transport_none_lib/spdm_transport_none_lib.h
+++ b/spdm_emu/spdm_transport_none_lib/spdm_transport_none_lib.h
@@ -1,0 +1,101 @@
+/**
+    Copyright Notice:
+    Copyright 2021 DMTF, Componolit. All rights reserved.
+    License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
+**/
+
+#ifndef __SPDM_NONE_TRANSPORT_LIB_H__
+#define __SPDM_NONE_TRANSPORT_LIB_H__
+
+#include <library/spdm_common_lib.h>
+
+
+/**
+  Encode an SPDM or APP message to a transport layer message.
+
+  For normal SPDM message, it adds the transport layer wrapper.
+  For secured SPDM message, it encrypts a secured message then adds the transport layer wrapper.
+  For secured APP message, it encrypts a secured message then adds the transport layer wrapper.
+
+  The APP message is encoded to a secured message directly in SPDM session.
+  The APP message format is defined by the transport layer.
+  Take MCTP as example: APP message == MCTP header (MCTP_MESSAGE_TYPE_SPDM) + SPDM message
+
+  @param  spdm_context                  A pointer to the SPDM context.
+  @param  session_id                    Indicates if it is a secured message protected via SPDM session.
+                                       If session_id is NULL, it is a normal message.
+                                       If session_id is NOT NULL, it is a secured message.
+  @param  is_app_message                 Indicates if it is an APP message or SPDM message.
+  @param  is_requester                  Indicates if it is a requester message.
+  @param  message_size                  size in bytes of the message data buffer.
+  @param  message                      A pointer to a source buffer to store the message.
+  @param  transport_message_size         size in bytes of the transport message data buffer.
+  @param  transport_message             A pointer to a destination buffer to store the transport message.
+
+  @retval RETURN_SUCCESS               The message is encoded successfully.
+  @retval RETURN_INVALID_PARAMETER     The message is NULL or the message_size is zero.
+**/
+return_status spdm_transport_none_encode_message(
+	IN void *spdm_context, IN uint32 *session_id, IN boolean is_app_message,
+	IN boolean is_requester, IN uintn message_size, IN void *message,
+	IN OUT uintn *transport_message_size, OUT void *transport_message);
+
+/**
+  Decode an SPDM or APP message from a transport layer message.
+
+  For normal SPDM message, it removes the transport layer wrapper,
+  For secured SPDM message, it removes the transport layer wrapper, then decrypts and verifies a secured message.
+  For secured APP message, it removes the transport layer wrapper, then decrypts and verifies a secured message.
+
+  The APP message is decoded from a secured message directly in SPDM session.
+  The APP message format is defined by the transport layer.
+  Take MCTP as example: APP message == MCTP header (MCTP_MESSAGE_TYPE_SPDM) + SPDM message
+
+  @param  spdm_context                  A pointer to the SPDM context.
+  @param  session_id                    Indicates if it is a secured message protected via SPDM session.
+                                       If *session_id is NULL, it is a normal message.
+                                       If *session_id is NOT NULL, it is a secured message.
+  @param  is_app_message                 Indicates if it is an APP message or SPDM message.
+  @param  is_requester                  Indicates if it is a requester message.
+  @param  transport_message_size         size in bytes of the transport message data buffer.
+  @param  transport_message             A pointer to a source buffer to store the transport message.
+  @param  message_size                  size in bytes of the message data buffer.
+  @param  message                      A pointer to a destination buffer to store the message.
+
+  @retval RETURN_SUCCESS               The message is decoded successfully.
+  @retval RETURN_INVALID_PARAMETER     The message is NULL or the message_size is zero.
+  @retval RETURN_UNSUPPORTED           The transport_message is unsupported.
+**/
+return_status spdm_transport_none_decode_message(
+	IN void *spdm_context, OUT uint32 **session_id,
+	OUT boolean *is_app_message, IN boolean is_requester,
+	IN uintn transport_message_size, IN void *transport_message,
+	IN OUT uintn *message_size, OUT void *message);
+
+/**
+  Get sequence number in an SPDM secure message.
+
+  This value is transport layer specific.
+
+  @param sequence_number        The current sequence number used to encode or decode message.
+  @param sequence_number_buffer  A buffer to hold the sequence number output used in the secured message.
+                               The size in byte of the output buffer shall be 8.
+
+  @return size in byte of the sequence_number_buffer.
+          It shall be no greater than 8.
+          0 means no sequence number is required.
+**/
+uint8 spdm_none_get_sequence_number(IN uint64 sequence_number,
+				    IN OUT uint8 *sequence_number_buffer);
+
+/**
+  Return max random number count in an SPDM secure message.
+
+  This value is transport layer specific.
+
+  @return Max random number count in an SPDM secured message.
+          0 means no randum number is required.
+**/
+uint32 spdm_none_get_max_random_number_count(void);
+
+#endif


### PR DESCRIPTION
We're using this tool to test a library that doesn't support MCTP or PCI DOE. For that I added a transport option to use SPDM without any transport protocol (except the header that the emu tool itself uses).
I'd like to discuss if we can integrate this change into this repository.