### PR TITLE
Add function call swtich, when disable SPDM_ENABLE_CAPABILITY_***_CAP

### DIFF
--- a/spdm_emu/spdm_requester_emu/spdm_requester_authentication.c
+++ b/spdm_emu/spdm_requester_emu/spdm_requester_authentication.c
@@ -6,6 +6,8 @@
 
 #include "spdm_requester_emu.h"
 
+#if (SPDM_ENABLE_CAPABILITY_CERT_CAP && SPDM_ENABLE_CAPABILITY_CHAL_CAP)
+
 extern void *m_spdm_context;
 
 /**
@@ -95,3 +97,5 @@ return_status do_authentication_via_spdm(void)
 	}
 	return RETURN_SUCCESS;
 }
+
+#endif //(SPDM_ENABLE_CAPABILITY_CERT_CAP && SPDM_ENABLE_CAPABILITY_CHAL_CAP)

--- a/spdm_emu/spdm_requester_emu/spdm_requester_emu.c
+++ b/spdm_emu/spdm_requester_emu/spdm_requester_emu.c
@@ -27,9 +27,13 @@ boolean communicate_platform_data(IN SOCKET socket, IN uint32_t command,
 				  IN OUT uintn *bytes_to_receive,
 				  OUT uint8_t *receive_buffer);
 
+#if SPDM_ENABLE_CAPABILITY_MEAS_CAP
 return_status do_measurement_via_spdm(IN uint32_t *session_id);
+#endif //SPDM_ENABLE_CAPABILITY_MEAS_CAP
 
+#if (SPDM_ENABLE_CAPABILITY_CERT_CAP && SPDM_ENABLE_CAPABILITY_CHAL_CAP)
 return_status do_authentication_via_spdm(void);
+#endif //(SPDM_ENABLE_CAPABILITY_CERT_CAP && SPDM_ENABLE_CAPABILITY_CHAL_CAP)
 
 return_status do_session_via_spdm(IN boolean use_psk);
 
@@ -157,13 +161,15 @@ boolean platform_client_routine(IN uint16_t port_number)
 	}
 
 	// Do test - begin
-
+#if (SPDM_ENABLE_CAPABILITY_CERT_CAP && SPDM_ENABLE_CAPABILITY_CHAL_CAP)
 	status = do_authentication_via_spdm();
 	if (RETURN_ERROR(status)) {
 		printf("do_authentication_via_spdm - %x\n", (uint32_t)status);
 		goto done;
 	}
+#endif //(SPDM_ENABLE_CAPABILITY_CERT_CAP && SPDM_ENABLE_CAPABILITY_CHAL_CAP)
 
+#if SPDM_ENABLE_CAPABILITY_MEAS_CAP
 	if ((m_exe_connection & EXE_CONNECTION_MEAS) != 0) {
 		status = do_measurement_via_spdm(NULL);
 		if (RETURN_ERROR(status)) {
@@ -172,6 +178,7 @@ boolean platform_client_routine(IN uint16_t port_number)
 			goto done;
 		}
 	}
+#endif //SPDM_ENABLE_CAPABILITY_MEAS_CAP
 
 	if (m_use_version >= SPDM_MESSAGE_VERSION_11) {
 		if ((m_exe_session & EXE_SESSION_KEY_EX) != 0) {

--- a/spdm_emu/spdm_requester_emu/spdm_requester_measurement.c
+++ b/spdm_emu/spdm_requester_emu/spdm_requester_measurement.c
@@ -6,6 +6,8 @@
 
 #include "spdm_requester_emu.h"
 
+#if SPDM_ENABLE_CAPABILITY_MEAS_CAP
+
 extern void *m_spdm_context;
 
 /**
@@ -96,3 +98,5 @@ return_status do_measurement_via_spdm(IN uint32_t *session_id)
 	}
 	return RETURN_SUCCESS;
 }
+
+#endif //SPDM_ENABLE_CAPABILITY_MEAS_CAP

--- a/spdm_emu/spdm_requester_emu/spdm_requester_session.c
+++ b/spdm_emu/spdm_requester_emu/spdm_requester_session.c
@@ -16,7 +16,9 @@ boolean communicate_platform_data(IN SOCKET socket, IN uint32_t command,
 				  IN OUT uintn *bytes_to_receive,
 				  OUT uint8_t *receive_buffer);
 
+#if SPDM_ENABLE_CAPABILITY_MEAS_CAP
 return_status do_measurement_via_spdm(IN uint32_t *session_id);
+#endif //SPDM_ENABLE_CAPABILITY_MEAS_CAP
 
 spdm_vendor_defined_request_mine_t mVendorDefinedRequest = {
 	{
@@ -188,6 +190,7 @@ return_status do_session_via_spdm(IN boolean use_psk)
 		}
 	}
 
+#if SPDM_ENABLE_CAPABILITY_MEAS_CAP
 	if ((m_exe_session & EXE_SESSION_MEAS) != 0) {
 		status = do_measurement_via_spdm(&session_id);
 		if (RETURN_ERROR(status)) {
@@ -195,6 +198,7 @@ return_status do_session_via_spdm(IN boolean use_psk)
 			       (uint32_t)status);
 		}
 	}
+#endif //SPDM_ENABLE_CAPABILITY_MEAS_CAP
 
 	if ((m_exe_session & EXE_SESSION_NO_END) == 0) {
 		status = libspdm_stop_session(spdm_context, session_id,


### PR DESCRIPTION
Fix: #25 
Some wrong function were called, when disable SPDM_ENABLE_CAPABILITY_***_CAP.

Signed-off-by: Wenxing Hou <wenxing.hou@intel.com>