### PR TITLE
Create build CI test

### DIFF
--- a/.github/workflows/build_CI.yml
+++ b/.github/workflows/build_CI.yml
@@ -1,0 +1,116 @@
+name: build_CI_test
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ main ]
+
+env:
+  BUILD_TYPE: Release
+
+jobs:
+  format_check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        # If any *.c *.h *.md file(except:libspdm) have Tab, the check will fail.
+      - name: Check code format
+        run: |
+          if grep -rn "	" * --include=*.c --include=*.h --include=*.md;
+          then exit 1
+          fi
+
+  gcc_mbedtls_build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+
+      - name: Build
+        run: |
+          mkdir build
+          cd build
+          cmake -DARCH=x64 -DTOOLCHAIN=GCC -DTARGET=Release -DCRYPTO=mbedtls ..
+          make copy_sample_key
+          make -j2
+      - name: Test
+        run: |
+          cd build/bin
+          ./spdm_responder_emu &
+          ./spdm_requester_emu
+
+  gcc_openssl_build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+
+      - name: Build
+        run: |
+          mkdir build
+          cd build
+          cmake -DARCH=x64 -DTOOLCHAIN=GCC -DTARGET=Release -DCRYPTO=openssl ..
+          make copy_sample_key
+          make -j2
+      - name: Test
+        run: |
+          cd build/bin
+          ./spdm_responder_emu &
+          ./spdm_requester_emu
+
+  VS2019_mbedtls_build:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+        #ilammy/msvc-dev-cmd@v1 is GitHub Action for configuring Developer Command Prompt for Microsoft Visual Studio on Windows.
+        #This sets up the environment for compiling C/C++ code from command line.
+      - name: Add msbuild to PATH
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: x64
+
+      - name: Build
+        run: |
+          mkdir build
+          cd build
+          cmake -G"NMake Makefiles" -DARCH=x64 -DTOOLCHAIN=VS2019 -DTARGET=Release -DCRYPTO=mbedtls ..
+          nmake  copy_sample_key
+          nmake
+      - name: Test
+        run: |
+          cd build/bin
+          ./spdm_responder_emu &
+          ./spdm_requester_emu
+
+  VS2019_openssl_build:
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+        #ilammy/msvc-dev-cmd@v1 is GitHub Action for configuring Developer Command Prompt for Microsoft Visual Studio on Windows.
+        #This sets up the environment for compiling C/C++ code from command line.
+      - name: Add msbuild to PATH
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: x64
+
+      - name: Build
+        run: |
+          mkdir build
+          cd build
+          cmake -G"NMake Makefiles" -DARCH=x64 -DTOOLCHAIN=VS2019 -DTARGET=Release -DCRYPTO=openssl ..
+          nmake  copy_sample_key
+          nmake
+      - name: Test
+        run: |
+          cd build/bin
+          ./spdm_responder_emu &
+          ./spdm_requester_emu


### PR DESCRIPTION
Fix: #37 

Add VS mbedltls/openssl x64 build CI test. 
Add gcc mbedltls/openssl x64 build CI test.
And the CI test can check the SPDM communication.

Signed-off-by: Wenxing Hou wenxing.hou@intel.com