### PR TITLE
Set default version to 0.

### DIFF
--- a/spdm_emu/spdm_emu_common/key.c
+++ b/spdm_emu/spdm_emu_common/key.c
@@ -6,8 +6,8 @@
 
 #include "spdm_emu.h"
 
-uint8_t m_use_version = SPDM_MESSAGE_VERSION_12;
-uint8_t m_use_secured_message_version = SPDM_MESSAGE_VERSION_11;
+uint8_t m_use_version = 0;
+uint8_t m_use_secured_message_version = 0;
 uint32_t m_use_requester_capability_flags =
     (0 |
      SPDM_GET_CAPABILITIES_REQUEST_FLAGS_CERT_CAP | /* conflict with SPDM_GET_CAPABILITIES_REQUEST_FLAGS_PUB_KEY_ID_CAP */

--- a/spdm_emu/spdm_requester_emu/spdm_requester_spdm.c
+++ b/spdm_emu/spdm_requester_emu/spdm_requester_spdm.c
@@ -166,7 +166,7 @@ void *spdm_client_init(void)
         spdm_load_negotiated_state(spdm_context, TRUE);
     }
 
-    {
+    if (m_use_version != 0) {
         zero_mem(&parameter, sizeof(parameter));
         parameter.location = LIBSPDM_DATA_LOCATION_LOCAL;
         spdm_version = m_use_version << SPDM_VERSION_NUMBER_SHIFT_BIT;
@@ -174,20 +174,14 @@ void *spdm_client_init(void)
                   &spdm_version, sizeof(spdm_version));
     }
 
-    {
+    if (m_use_secured_message_version != 0) {
         zero_mem(&parameter, sizeof(parameter));
-        if (m_use_secured_message_version != 0) {
-            parameter.location = LIBSPDM_DATA_LOCATION_LOCAL;
-            spdm_version = m_use_secured_message_version << SPDM_VERSION_NUMBER_SHIFT_BIT;
-            libspdm_set_data(spdm_context,
+        parameter.location = LIBSPDM_DATA_LOCATION_LOCAL;
+        spdm_version = m_use_secured_message_version << SPDM_VERSION_NUMBER_SHIFT_BIT;
+        libspdm_set_data(spdm_context,
                       LIBSPDM_DATA_SECURED_MESSAGE_VERSION,
                       &parameter, &spdm_version,
                       sizeof(spdm_version));
-        } else {
-            libspdm_set_data(spdm_context,
-                      LIBSPDM_DATA_SECURED_MESSAGE_VERSION,
-                      &parameter, NULL, 0);
-        }
     }
 
     zero_mem(&parameter, sizeof(parameter));

--- a/spdm_emu/spdm_responder_emu/spdm_responder_spdm.c
+++ b/spdm_emu/spdm_responder_emu/spdm_responder_spdm.c
@@ -139,7 +139,7 @@ void *spdm_server_init(void)
         spdm_load_negotiated_state(spdm_context, FALSE);
     }
 
-    {
+    if (m_use_version != 0) {
         zero_mem(&parameter, sizeof(parameter));
         parameter.location = LIBSPDM_DATA_LOCATION_LOCAL;
         spdm_version = m_use_version << SPDM_VERSION_NUMBER_SHIFT_BIT;
@@ -147,20 +147,14 @@ void *spdm_server_init(void)
                   &spdm_version, sizeof(spdm_version));
     }
 
-    {
+    if (m_use_secured_message_version != 0) {
         zero_mem(&parameter, sizeof(parameter));
-        if (m_use_secured_message_version != 0) {
-            parameter.location = LIBSPDM_DATA_LOCATION_LOCAL;
-            spdm_version = m_use_secured_message_version << SPDM_VERSION_NUMBER_SHIFT_BIT;
-            libspdm_set_data(spdm_context,
+        parameter.location = LIBSPDM_DATA_LOCATION_LOCAL;
+        spdm_version = m_use_secured_message_version << SPDM_VERSION_NUMBER_SHIFT_BIT;
+        libspdm_set_data(spdm_context,
                       LIBSPDM_DATA_SECURED_MESSAGE_VERSION,
                       &parameter, &spdm_version,
                       sizeof(spdm_version));
-        } else {
-            libspdm_set_data(spdm_context,
-                      LIBSPDM_DATA_SECURED_MESSAGE_VERSION,
-                      &parameter, NULL, 0);
-        }
     }
 
     zero_mem(&parameter, sizeof(parameter));


### PR DESCRIPTION
If the user does not indicate the version,
the emulator uses the default version in libspdm.

That is to cover 1.0/1.1/1.2.

Signed-off-by: Jiewen Yao <jiewen.yao@intel.com>