### PR TITLE
Add emu test for libspdm 1.2 new feature:set_certificate

### DIFF
--- a/spdm_emu/spdm_emu_common/spdm_emu.c
+++ b/spdm_emu/spdm_emu_common/spdm_emu.c
@@ -20,7 +20,7 @@ uint32_t m_exe_connection = (0 |
 uint32_t m_exe_session =
     (0 | EXE_SESSION_KEY_EX | EXE_SESSION_PSK |
      /* EXE_SESSION_NO_END |*/
-     EXE_SESSION_KEY_UPDATE | EXE_SESSION_HEARTBEAT | EXE_SESSION_MEAS | 0);
+     EXE_SESSION_KEY_UPDATE | EXE_SESSION_HEARTBEAT | EXE_SESSION_MEAS | EXE_SESSION_SET_CERT | 0);
 
 void print_usage(const char *name)
 {

--- a/spdm_emu/spdm_emu_common/spdm_emu.h
+++ b/spdm_emu/spdm_emu_common/spdm_emu.h
@@ -77,6 +77,7 @@ extern uint32_t m_exe_connection;
 #define EXE_SESSION_KEY_UPDATE 0x8
 #define EXE_SESSION_HEARTBEAT 0x10
 #define EXE_SESSION_MEAS 0x20
+#define EXE_SESSION_SET_CERT 0x40
 extern uint32_t m_exe_session;
 
 void libspdm_dump_hex_str(const uint8_t *buffer, size_t buffer_size);


### PR DESCRIPTION

Set cert for slot_id 0 and 1 in emu unit test suceessfully: 
1. Set cert for slot_id 0 in secure environment;
2. Set cert for slot_id 1 in secure session.

Signed-off-by: Wenxing Hou <wenxing.hou@intel.com>