### PR TITLE
Cleanup headers in preparation for libspdm header cleanup

### DIFF
--- a/library/mctp_requester_lib/mctp_send_receive.c
+++ b/library/mctp_requester_lib/mctp_send_receive.c
@@ -6,6 +6,7 @@
 
 #include "hal/base.h"
 #include "hal/library/memlib.h"
+#include "hal/library/debuglib.h"
 #include "library/spdm_requester_lib.h"
 #include "library/spdm_transport_mctp_lib.h"
 #include "library/mctp_requester_lib.h"

--- a/library/mctp_responder_lib/mctp_dispatch.c
+++ b/library/mctp_responder_lib/mctp_dispatch.c
@@ -6,6 +6,7 @@
 
 #include "hal/base.h"
 #include "hal/library/memlib.h"
+#include "hal/library/debuglib.h"
 #include "library/spdm_requester_lib.h"
 #include "library/spdm_transport_mctp_lib.h"
 #include "library/mctp_responder_lib.h"

--- a/library/mctp_responder_lib/pldm_rsp_control_get_tid.c
+++ b/library/mctp_responder_lib/pldm_rsp_control_get_tid.c
@@ -6,6 +6,7 @@
 
 #include "hal/base.h"
 #include "hal/library/memlib.h"
+#include "hal/library/debuglib.h"
 #include "library/spdm_requester_lib.h"
 #include "library/spdm_transport_mctp_lib.h"
 #include "library/mctp_responder_lib.h"

--- a/library/pci_doe_requester_lib/pci_doe_req_discovery.c
+++ b/library/pci_doe_requester_lib/pci_doe_req_discovery.c
@@ -6,6 +6,7 @@
 
 #include "hal/base.h"
 #include "hal/library/memlib.h"
+#include "hal/library/debuglib.h"
 #include "library/spdm_requester_lib.h"
 #include "library/spdm_transport_pcidoe_lib.h"
 #include "library/pci_doe_requester_lib.h"

--- a/library/pci_doe_requester_lib/pci_doe_spdm_vendor_send_receive.c
+++ b/library/pci_doe_requester_lib/pci_doe_spdm_vendor_send_receive.c
@@ -6,6 +6,7 @@
 
 #include "hal/base.h"
 #include "hal/library/memlib.h"
+#include "hal/library/debuglib.h"
 #include "library/spdm_requester_lib.h"
 #include "library/spdm_transport_pcidoe_lib.h"
 #include "library/pci_doe_requester_lib.h"

--- a/library/pci_doe_responder_lib/pci_doe_spdm_vendor_dispatch.c
+++ b/library/pci_doe_responder_lib/pci_doe_spdm_vendor_dispatch.c
@@ -6,6 +6,7 @@
 
 #include "hal/base.h"
 #include "hal/library/memlib.h"
+#include "hal/library/debuglib.h"
 #include "library/spdm_requester_lib.h"
 #include "library/spdm_transport_pcidoe_lib.h"
 #include "library/pci_doe_responder_lib.h"
@@ -92,7 +93,7 @@ libspdm_return_t pci_doe_get_response_spdm_vendor_defined_request(const void *pc
             libspdm_zero_mem (spdm_response, sizeof(pci_doe_spdm_vendor_defined_response_t));
             spdm_response->spdm_header.spdm_version = spdm_request->spdm_header.spdm_version;
             spdm_response->spdm_header.request_response_code = SPDM_VENDOR_DEFINED_RESPONSE;
-            spdm_response->pci_doe_vendor_header.standard_id = 
+            spdm_response->pci_doe_vendor_header.standard_id =
                 spdm_request->pci_doe_vendor_header.standard_id;
             spdm_response->pci_doe_vendor_header.len =
                 sizeof(spdm_response->pci_doe_vendor_header.vendor_id);

--- a/library/pci_ide_km_responder_lib/pci_ide_km_rsp_key_prog.c
+++ b/library/pci_ide_km_responder_lib/pci_ide_km_rsp_key_prog.c
@@ -6,6 +6,7 @@
 
 #include "hal/base.h"
 #include "hal/library/memlib.h"
+#include "hal/library/debuglib.h"
 #include "library/spdm_requester_lib.h"
 #include "library/spdm_transport_pcidoe_lib.h"
 #include "library/pci_ide_km_device_lib.h"

--- a/library/pci_ide_km_responder_lib/pci_ide_km_rsp_key_set_go.c
+++ b/library/pci_ide_km_responder_lib/pci_ide_km_rsp_key_set_go.c
@@ -6,6 +6,7 @@
 
 #include "hal/base.h"
 #include "hal/library/memlib.h"
+#include "hal/library/debuglib.h"
 #include "library/spdm_requester_lib.h"
 #include "library/spdm_transport_pcidoe_lib.h"
 #include "library/pci_ide_km_device_lib.h"

--- a/library/pci_ide_km_responder_lib/pci_ide_km_rsp_key_set_stop.c
+++ b/library/pci_ide_km_responder_lib/pci_ide_km_rsp_key_set_stop.c
@@ -6,6 +6,7 @@
 
 #include "hal/base.h"
 #include "hal/library/memlib.h"
+#include "hal/library/debuglib.h"
 #include "library/spdm_requester_lib.h"
 #include "library/spdm_transport_pcidoe_lib.h"
 #include "library/pci_ide_km_device_lib.h"

--- a/library/pci_ide_km_responder_lib/pci_ide_km_rsp_query.c
+++ b/library/pci_ide_km_responder_lib/pci_ide_km_rsp_query.c
@@ -6,6 +6,7 @@
 
 #include "hal/base.h"
 #include "hal/library/memlib.h"
+#include "hal/library/debuglib.h"
 #include "library/spdm_requester_lib.h"
 #include "library/spdm_transport_pcidoe_lib.h"
 #include "library/pci_ide_km_device_lib.h"

--- a/library/spdm_transport_none_lib/common.c
+++ b/library/spdm_transport_none_lib/common.c
@@ -6,6 +6,7 @@
 
 #include "library/spdm_transport_none_lib.h"
 #include "library/spdm_secured_message_lib.h"
+#include "hal/library/debuglib.h"
 
 /**
  * Encode a normal message or secured message to a transport message.


### PR DESCRIPTION
https://github.com/DMTF/libspdm/pull/1029 requires debuglib.h to be #included from hal/library.

Signed-off-by: Steven Bellock <sbellock@nvidia.com>