### PR TITLE
use option 2(don't send Secure SPDM message if trans is NONE) to fix the bug when use --trans NONE

### DIFF
--- a/spdm_emu/spdm_requester_emu/spdm_requester_session.c
+++ b/spdm_emu/spdm_requester_emu/spdm_requester_session.c
@@ -24,6 +24,7 @@ libspdm_return_t do_measurement_via_spdm(const uint32_t *session_id);
 
 libspdm_return_t pci_doe_process_session_message(void *spdm_context, uint32_t session_id);
 libspdm_return_t mctp_process_session_message(void *spdm_context, uint32_t session_id);
+libspdm_return_t do_certificate_provising_via_spdm(uint32_t* session_id);
 
 libspdm_return_t do_app_session_via_spdm(uint32_t session_id)
 {
@@ -82,21 +83,6 @@ libspdm_return_t do_session_via_spdm(bool use_psk)
     size_t response_size;
     bool result;
     uint32_t response;
-
-#if LIBSPDM_ENABLE_CAPABILITY_GET_CSR_CAP
-    uint8_t csr_form_get[LIBSPDM_MAX_CSR_SIZE];
-    size_t csr_len;
-#endif /*LIBSPDM_ENABLE_CAPABILITY_GET_CSR_CAP*/
-
-#if LIBSPDM_ENABLE_SET_CERTIFICATE_CAP
-    void *cert_chain_to_set;
-    size_t cert_chain_size_to_set;
-    uint8_t slot_id;
-    bool res;
-
-    cert_chain_to_set = NULL;
-    cert_chain_size_to_set = 0;
-#endif /*LIBSPDM_ENABLE_SET_CERTIFICATE_CAP*/
 
     spdm_context = m_spdm_context;
 
@@ -186,65 +172,14 @@ libspdm_return_t do_session_via_spdm(bool use_psk)
     }
 #endif
 
-#if LIBSPDM_ENABLE_CAPABILITY_GET_CSR_CAP
-    /*get csr*/
-    if (m_use_version >= SPDM_MESSAGE_VERSION_12) {
-        csr_len = LIBSPDM_MAX_CSR_SIZE;
-        libspdm_zero_mem(csr_form_get, sizeof(csr_form_get));
-        if ((m_exe_session & EXE_SESSION_GET_CSR) != 0) {
-            status = libspdm_get_csr(spdm_context, NULL, 0, NULL, 0, NULL, csr_form_get,
-                                    &csr_len);
-            if (LIBSPDM_STATUS_IS_ERROR(status)) {
-                printf("libspdm_get_csr - %x\n",
-                        (uint32_t)status);
-            }
+    if (m_use_version >= SPDM_MESSAGE_VERSION_12) {      
+        status = do_certificate_provising_via_spdm(&session_id);
+        if (LIBSPDM_STATUS_IS_ERROR(status)) {
+            printf("do_certificate_provising_via_spdm - %x\n",
+                (uint32_t)status);
+            return status;
         }
-    }    
-#endif /*LIBSPDM_ENABLE_CAPABILITY_GET_CSR_CAP*/
-
-#if LIBSPDM_ENABLE_SET_CERTIFICATE_CAP
-    if (m_use_version >= SPDM_MESSAGE_VERSION_12) {
-        res = libspdm_read_responder_public_certificate_chain(m_use_hash_algo,
-                                                            m_use_asym_algo,
-                                                            &cert_chain_to_set,
-                                                            &cert_chain_size_to_set,
-                                                            NULL, NULL);
-        if (!res) {
-            printf("set certificate :read_responder_public_certificate_chain fail!\n");
-            free(cert_chain_to_set);
-            return LIBSPDM_STATUS_SEND_FAIL;
-        }
-
-        /*set_certificate for slot_id:0 in secure environment*/
-        if ((m_exe_session & EXE_SESSION_SET_CERT) != 0) {
-            slot_id = 0;
-            status = libspdm_set_certificate(spdm_context, slot_id,
-                                            cert_chain_to_set, cert_chain_size_to_set, NULL);
-
-            if (LIBSPDM_STATUS_IS_ERROR(status)) {
-                printf("libspdm_set_certificate - %x\n",
-                        (uint32_t)status);
-            }
-
-        }
-
-        /*set_certificate for slot_id:1 in secure session*/
-        if ((m_exe_session & EXE_SESSION_SET_CERT) != 0) {
-            slot_id = 1;
-            status = libspdm_set_certificate(spdm_context, slot_id,
-                                            cert_chain_to_set, cert_chain_size_to_set, &session_id);
-
-            if (LIBSPDM_STATUS_IS_ERROR(status)) {
-                printf("libspdm_set_certificate - %x\n",
-                        (uint32_t)status);
-            }
-
-        }
-
-        free(cert_chain_to_set);
     }
-#endif /*LIBSPDM_ENABLE_SET_CERTIFICATE_CAP*/
-
 
     if ((m_exe_session & EXE_SESSION_NO_END) == 0) {
         status = libspdm_stop_session(spdm_context, session_id,
@@ -256,6 +191,123 @@ libspdm_return_t do_session_via_spdm(bool use_psk)
     }
 
     return status;
+}
+
+libspdm_return_t do_handshake_via_spdm(void)
+{
+    void *spdm_context;
+    libspdm_return_t status;
+    uint32_t session_id;
+    uint8_t heartbeat_period;
+    uint8_t measurement_hash[LIBSPDM_MAX_HASH_SIZE];
+
+    spdm_context = m_spdm_context;
+    heartbeat_period = 0;
+    
+    libspdm_zero_mem(measurement_hash, sizeof(measurement_hash));
+    /* Only test KEY_EXCHANGE and FINISH request messages */
+    status = libspdm_start_session(spdm_context, false,
+                                   m_use_measurement_summary_hash_type,
+                                   m_use_slot_id, m_session_policy, &session_id,
+                                   &heartbeat_period, measurement_hash);
+    if (LIBSPDM_STATUS_IS_ERROR(status)) {
+        printf("libspdm_start_session - %x\n", (uint32_t)status);
+        return status;
+    }
+
+    return LIBSPDM_SEVERITY_SUCCESS;
+}
+
+/*
+* These function implements the request and response messages used for provisioning a device with certificate chains.
+* Provisioning of Slot 0 should be only done in a secure environment (such as a secure manufacturing environment)
+*/
+libspdm_return_t do_certificate_provising_via_spdm(uint32_t* session_id)
+{
+    void *spdm_context;
+
+#if LIBSPDM_ENABLE_CAPABILITY_GET_CSR_CAP
+    uint8_t csr_form_get[LIBSPDM_MAX_CSR_SIZE];
+    size_t csr_len;
+#endif /*LIBSPDM_ENABLE_CAPABILITY_GET_CSR_CAP*/
+
+#if LIBSPDM_ENABLE_SET_CERTIFICATE_CAP
+    void *cert_chain_to_set;
+    size_t cert_chain_size_to_set;
+    uint8_t slot_id;
+    bool res;
+
+    cert_chain_to_set = NULL;
+    cert_chain_size_to_set = 0;
+#endif /*LIBSPDM_ENABLE_SET_CERTIFICATE_CAP*/
+
+    libspdm_return_t status;
+    spdm_context = m_spdm_context;
+
+#if LIBSPDM_ENABLE_CAPABILITY_GET_CSR_CAP
+
+    /*get csr*/
+    csr_len = LIBSPDM_MAX_CSR_SIZE;
+    libspdm_zero_mem(csr_form_get, sizeof(csr_form_get));
+    if ((m_exe_session & EXE_SESSION_GET_CSR) != 0) {
+        status = libspdm_get_csr(spdm_context, NULL, 0, NULL, 0, NULL, csr_form_get,
+                                &csr_len);
+        if (LIBSPDM_STATUS_IS_ERROR(status)) {
+            printf("libspdm_get_csr - %x\n",
+                    (uint32_t)status);
+            return status;
+        }
+    }
+ 
+#endif /*LIBSPDM_ENABLE_CAPABILITY_GET_CSR_CAP*/
+
+#if LIBSPDM_ENABLE_SET_CERTIFICATE_CAP
+    res = libspdm_read_responder_public_certificate_chain(m_use_hash_algo,
+                                                        m_use_asym_algo,
+                                                        &cert_chain_to_set,
+                                                        &cert_chain_size_to_set,
+                                                        NULL, NULL);
+    if (!res) {
+        printf("set certificate :read_responder_public_certificate_chain fail!\n");
+        free(cert_chain_to_set);
+        return LIBSPDM_STATUS_INVALID_CERT;
+    }
+
+    /*set_certificate for slot_id:0 in secure environment*/
+    if ((m_exe_session & EXE_SESSION_SET_CERT) != 0) {
+        slot_id = 0;
+        status = libspdm_set_certificate(spdm_context, slot_id,
+                                        cert_chain_to_set, cert_chain_size_to_set, NULL);
+
+        if (LIBSPDM_STATUS_IS_ERROR(status)) {
+            printf("libspdm_set_certificate - %x\n",
+                (uint32_t)status);
+            free(cert_chain_to_set);
+            return status;
+        }
+
+    }
+
+    /*set_certificate for slot_id:1 in secure session*/
+    if (session_id != NULL) {
+        if ((m_exe_session & EXE_SESSION_SET_CERT) != 0) {
+            slot_id = 1;
+            status = libspdm_set_certificate(spdm_context, slot_id,
+                                            cert_chain_to_set, cert_chain_size_to_set, session_id);
+
+            if (LIBSPDM_STATUS_IS_ERROR(status)) {
+                printf("libspdm_set_certificate - %x\n",
+                            (uint32_t)status);
+            }
+
+            free(cert_chain_to_set);
+            return status;
+        }
+    }
+
+    free(cert_chain_to_set);
+#endif /*LIBSPDM_ENABLE_SET_CERTIFICATE_CAP*/ 
+    return LIBSPDM_SEVERITY_SUCCESS;  
 }
 
 #endif /*(LIBSPDM_ENABLE_CAPABILITY_KEY_EX_CAP || LIBSPDM_ENABLE_CAPABILITY_PSK_EX_CAP)*/


### PR DESCRIPTION
use option 2(don't send Secure SPDM message if trans is NONE) to fix the bug when use --trans NONE

more details in [here](https://github.com/DMTF/spdm-emu/pull/108)

Signed-off-by: li_binbin <lbbxsxlz@gmail.com>

The function do_handshake_via_spdm do not include the PSK_EXCHANGE and PSK_FINISH request message.