### PR TITLE
skip secure session messages when use --trans NONE

### DIFF
--- a/library/spdm_transport_none_lib/common.c
+++ b/library/spdm_transport_none_lib/common.c
@@ -53,131 +53,9 @@ libspdm_return_t none_decode_message(uint32_t **session_id,
                                   void **message);
 
 /**
- * Encode an SPDM or APP message to a transport layer message.
+ * Encode an SPDM from a transport layer message.
  *
- * For normal SPDM message, it adds the transport layer wrapper.
- * For secured SPDM message, it encrypts a secured message then adds the transport layer wrapper.
- * For secured APP message, it encrypts a secured message then adds the transport layer wrapper.
- *
- * The APP message is encoded to a secured message directly in SPDM session.
- * The APP message format is defined by the transport layer.
- * Take MCTP as example: APP message == MCTP header (MCTP_MESSAGE_TYPE_SPDM) + SPDM message
- *
- * @param  spdm_context                  A pointer to the SPDM context.
- * @param  session_id                    Indicates if it is a secured message protected via SPDM session.
- *                                     If session_id is NULL, it is a normal message.
- *                                     If session_id is NOT NULL, it is a secured message.
- * @param  is_app_message                 Indicates if it is an APP message or SPDM message.
- * @param  is_requester                  Indicates if it is a requester message.
- * @param  message_size                  size in bytes of the message data buffer.
- * @param  message                      A pointer to a source buffer to store the message.
- *                                     For normal message, it shall point to the acquired sender buffer.
- *                                     For secured message, it shall point to the scratch buffer in spdm_context.
- * @param  transport_message_size         size in bytes of the transport message data buffer.
- * @param  transport_message             A pointer to a destination buffer to store the transport message.
- *                                     On input, it shall be msg_buf_ptr from sender buffer.
- *                                     On output, it will point to acquired sender buffer.
- *
- * @retval LIBSPDM_STATUS_SUCCESS               The message is encoded successfully.
- * @retval RETURN_INVALID_PARAMETER     The message is NULL or the message_size is zero.
- **/
-libspdm_return_t spdm_transport_none_encode_message(
-    void *spdm_context, const uint32_t *session_id, bool is_app_message,
-    bool is_requester, size_t message_size, void *message,
-    size_t *transport_message_size, void **transport_message)
-{
-    libspdm_return_t status;
-    void *app_message;
-    size_t app_message_size;
-    uint8_t *secured_message;
-    size_t secured_message_size;
-    libspdm_secured_message_callbacks_t spdm_secured_message_callbacks;
-    void *secured_message_context;
-    size_t transport_header_size;
-
-    spdm_secured_message_callbacks.version =
-        SPDM_SECURED_MESSAGE_CALLBACKS_VERSION;
-    spdm_secured_message_callbacks.get_sequence_number =
-        spdm_none_get_sequence_number;
-    spdm_secured_message_callbacks.get_max_random_number_count =
-        spdm_none_get_max_random_number_count;
-
-    if (is_app_message && (session_id == NULL)) {
-        return LIBSPDM_STATUS_UNSUPPORTED_CAP;
-    }
-
-    if (session_id != NULL) {
-        secured_message_context =
-            libspdm_get_secured_message_context_via_session_id(
-                spdm_context, *session_id);
-        if (secured_message_context == NULL) {
-            return LIBSPDM_STATUS_UNSUPPORTED_CAP;
-        }
-
-        if (!is_app_message) {
-            /* SPDM message to APP message*/
-            status = none_encode_message(NULL, message_size,
-                                         message,
-                                         &app_message_size,
-                                         &app_message);
-            if (LIBSPDM_STATUS_IS_ERROR(status)) {
-                LIBSPDM_DEBUG((LIBSPDM_DEBUG_ERROR,
-                               "transport_encode_message - %p\n",
-                               status));
-                return status;
-            }
-        } else {
-            app_message = (void *)message;
-            app_message_size = message_size;
-        }
-        /* APP message to secured message*/
-        transport_header_size = spdm_transport_none_get_header_size(spdm_context);
-        secured_message = (uint8_t *)*transport_message + transport_header_size;
-        secured_message_size = *transport_message_size - transport_header_size;
-        status = libspdm_encode_secured_message(
-            secured_message_context, *session_id, is_requester,
-            app_message_size, app_message, &secured_message_size,
-            secured_message, &spdm_secured_message_callbacks);
-        if (LIBSPDM_STATUS_IS_ERROR(status)) {
-            LIBSPDM_DEBUG((LIBSPDM_DEBUG_ERROR,
-                           "libspdm_encode_secured_message - %p\n", status));
-            return status;
-        }
-
-        /* secured message to secured MCTP message*/
-        status = none_encode_message(
-            session_id, secured_message_size, secured_message,
-            transport_message_size, transport_message);
-        if (LIBSPDM_STATUS_IS_ERROR(status)) {
-            LIBSPDM_DEBUG((LIBSPDM_DEBUG_ERROR, "transport_encode_message - %p\n",
-                           status));
-            return status;
-        }
-    } else {
-        /* SPDM message to normal MCTP message*/
-        status = none_encode_message(NULL, message_size, message,
-                                     transport_message_size,
-                                     transport_message);
-        if (LIBSPDM_STATUS_IS_ERROR(status)) {
-            LIBSPDM_DEBUG((LIBSPDM_DEBUG_ERROR, "transport_encode_message - %p\n",
-                           status));
-            return status;
-        }
-    }
-
-    return LIBSPDM_STATUS_SUCCESS;
-}
-
-/**
- * Decode an SPDM or APP message from a transport layer message.
- *
- * For normal SPDM message, it removes the transport layer wrapper,
- * For secured SPDM message, it removes the transport layer wrapper, then decrypts and verifies a secured message.
- * For secured APP message, it removes the transport layer wrapper, then decrypts and verifies a secured message.
- *
- * The APP message is decoded from a secured message directly in SPDM session.
- * The APP message format is defined by the transport layer.
- * Take MCTP as example: APP message == MCTP header (MCTP_MESSAGE_TYPE_SPDM) + SPDM message
+ * Only for normal SPDM message, it adds the transport layer wrapper.
  *
  * @param  spdm_context                  A pointer to the SPDM context.
  * @param  session_id                    Indicates if it is a secured message protected via SPDM session.
@@ -195,8 +73,53 @@ libspdm_return_t spdm_transport_none_encode_message(
  *                                     On output, for secured message, it will point to the scratch buffer in spdm_context.
  *
  * @retval LIBSPDM_STATUS_SUCCESS               The message is decoded successfully.
- * @retval RETURN_INVALID_PARAMETER     The message is NULL or the message_size is zero.
- * @retval RETURN_UNSUPPORTED           The transport_message is unsupported.
+ * @retval LIBSPDM_STATUS_UNSUPPORTED_CAP       The message is invalid.
+ **/
+libspdm_return_t spdm_transport_none_encode_message(
+    void *spdm_context, const uint32_t *session_id, bool is_app_message,
+    bool is_requester, size_t message_size, void *message,
+    size_t *transport_message_size, void **transport_message)
+{
+    libspdm_return_t status;
+
+    if (is_app_message && (session_id == NULL)) {
+        return LIBSPDM_STATUS_UNSUPPORTED_CAP;
+    }
+    /* normal message */
+    status = none_encode_message(NULL, message_size, message,
+                                transport_message_size,
+                                transport_message);
+    if (LIBSPDM_STATUS_IS_ERROR(status)) {
+        LIBSPDM_DEBUG((LIBSPDM_DEBUG_ERROR, "transport_encode_message - %p\n",
+                        status));
+        return status;
+    }
+
+    return LIBSPDM_STATUS_SUCCESS;
+}
+
+/**
+ * Decode an SPDM from a transport layer message.
+ *
+ * Only for normal SPDM message, it removes the transport layer wrapper.
+ *
+ * @param  spdm_context                  A pointer to the SPDM context.
+ * @param  session_id                    Indicates if it is a secured message protected via SPDM session.
+ *                                     If *session_id is NULL, it is a normal message.
+ *                                     If *session_id is NOT NULL, it is a secured message.
+ * @param  is_app_message                 Indicates if it is an APP message or SPDM message.
+ * @param  is_requester                  Indicates if it is a requester message.
+ * @param  transport_message_size         size in bytes of the transport message data buffer.
+ * @param  transport_message             A pointer to a source buffer to store the transport message.
+ *                                     For normal message or secured message, it shall point to acquired receiver buffer.
+ * @param  message_size                  size in bytes of the message data buffer.
+ * @param  message                      A pointer to a destination buffer to store the message.
+ *                                     On input, it shall be msg_buf_ptr from receiver buffer.
+ *                                     On output, for normal message, it will point to the original receiver buffer.
+ *                                     On output, for secured message, it will point to the scratch buffer in spdm_context.
+ *
+ * @retval LIBSPDM_STATUS_SUCCESS               The message is decoded successfully.
+ * @retval LIBSPDM_STATUS_UNSUPPORTED_CAP       The message is invalid.
  **/
 libspdm_return_t spdm_transport_none_decode_message(
     void *spdm_context, uint32_t **session_id,
@@ -204,109 +127,26 @@ libspdm_return_t spdm_transport_none_decode_message(
     size_t transport_message_size, void *transport_message,
     size_t *message_size, void **message)
 {
+    
     libspdm_return_t status;
-    uint32_t *secured_message_session_id;
-    uint8_t *secured_message;
-    size_t secured_message_size;
-    uint8_t *app_message;
-    size_t app_message_size;
-    libspdm_secured_message_callbacks_t spdm_secured_message_callbacks;
-    void *secured_message_context;
-    libspdm_error_struct_t spdm_error;
-
-    spdm_error.error_code = 0;
-    spdm_error.session_id = 0;
-    libspdm_set_last_spdm_error_struct(spdm_context, &spdm_error);
-
-    spdm_secured_message_callbacks.version =
-        SPDM_SECURED_MESSAGE_CALLBACKS_VERSION;
-    spdm_secured_message_callbacks.get_sequence_number =
-        spdm_none_get_sequence_number;
-    spdm_secured_message_callbacks.get_max_random_number_count =
-        spdm_none_get_max_random_number_count;
 
     if ((session_id == NULL) || (is_app_message == NULL)) {
         return LIBSPDM_STATUS_UNSUPPORTED_CAP;
     }
-
-    secured_message_session_id = NULL;
-    /* Detect received message*/
-    status = none_decode_message(
-        &secured_message_session_id, transport_message_size,
-        transport_message, &secured_message_size, (void **)&secured_message);
+    
+    /* get non-secured message*/
+    status = none_decode_message(NULL,
+                                transport_message_size,
+                                transport_message,
+                                message_size, message);
     if (LIBSPDM_STATUS_IS_ERROR(status)) {
-        LIBSPDM_DEBUG((LIBSPDM_DEBUG_ERROR, "transport_decode_message - %p\n", status));
+        LIBSPDM_DEBUG((LIBSPDM_DEBUG_ERROR, "transport_decode_message - %p\n",
+                        status));
         return status;
     }
 
-    if (secured_message_session_id != NULL) {
-        *session_id = secured_message_session_id;
-
-        secured_message_context =
-            libspdm_get_secured_message_context_via_session_id(
-                spdm_context, *secured_message_session_id);
-        if (secured_message_context == NULL) {
-            spdm_error.error_code = SPDM_ERROR_CODE_INVALID_SESSION;
-            spdm_error.session_id = *secured_message_session_id;
-            libspdm_set_last_spdm_error_struct(spdm_context,
-                                               &spdm_error);
-            return LIBSPDM_STATUS_UNSUPPORTED_CAP;
-        }
-
-        /* Secured message to APP message*/
-        app_message = *message;
-        app_message_size = *message_size;
-        status = libspdm_decode_secured_message(
-            secured_message_context, *secured_message_session_id,
-            is_requester, secured_message_size, secured_message,
-            &app_message_size, (void **)&app_message,
-            &spdm_secured_message_callbacks);
-        if (LIBSPDM_STATUS_IS_ERROR(status)) {
-            LIBSPDM_DEBUG((LIBSPDM_DEBUG_ERROR,
-                           "libspdm_decode_secured_message - %p\n", status));
-            libspdm_secured_message_get_last_spdm_error_struct(
-                secured_message_context, &spdm_error);
-            libspdm_set_last_spdm_error_struct(spdm_context,
-                                               &spdm_error);
-            return status;
-        }
-
-        /* APP message to SPDM message.*/
-        status = none_decode_message(&secured_message_session_id,
-                                     app_message_size, app_message,
-                                     message_size, message);
-        if (LIBSPDM_STATUS_IS_ERROR(status)) {
-            *is_app_message = true;
-            /* just return APP message.*/
-            *message = app_message;
-            *message_size = app_message_size;
-            return LIBSPDM_STATUS_SUCCESS;
-        } else {
-            *is_app_message = false;
-            if (secured_message_session_id == NULL) {
-                return LIBSPDM_STATUS_SUCCESS;
-            } else {
-                /* get encapsulated secured message - cannot handle it.*/
-                LIBSPDM_DEBUG((LIBSPDM_DEBUG_ERROR,
-                               "transport_decode_message - expect encapsulated normal but got session (%08x)\n",
-                               *secured_message_session_id));
-                return LIBSPDM_STATUS_UNSUPPORTED_CAP;
-            }
-        }
-    } else {
-        /* get non-secured message*/
-        status = none_decode_message(&secured_message_session_id,
-                                     transport_message_size,
-                                     transport_message,
-                                     message_size, message);
-        if (LIBSPDM_STATUS_IS_ERROR(status)) {
-            LIBSPDM_DEBUG((LIBSPDM_DEBUG_ERROR, "transport_decode_message - %p\n",
-                           status));
-            return status;
-        }
-        LIBSPDM_ASSERT(secured_message_session_id == NULL);
-        *session_id = NULL;
-        *is_app_message = false;
-        return LIBSPDM_STATUS_SUCCESS;
-    }
+    *session_id = NULL;
+    *is_app_message = false;
+    return LIBSPDM_STATUS_SUCCESS;
 }
+

--- a/spdm_emu/spdm_requester_emu/spdm_requester_emu.c
+++ b/spdm_emu/spdm_requester_emu/spdm_requester_emu.c
@@ -39,7 +39,7 @@ libspdm_return_t do_authentication_via_spdm(void);
 #endif /*(LIBSPDM_ENABLE_CAPABILITY_CERT_CAP && LIBSPDM_ENABLE_CAPABILITY_CHAL_CAP)*/
 
 libspdm_return_t do_session_via_spdm(bool use_psk);
-
+libspdm_return_t do_certificate_provising_via_spdm(uint32_t* session_id);
 
 bool init_client(SOCKET *sock, uint16_t port)
 {
@@ -152,40 +152,52 @@ bool platform_client_routine(uint16_t port_number)
         }
     }
 #endif /*LIBSPDM_ENABLE_CAPABILITY_MEAS_CAP*/
-
-#if (LIBSPDM_ENABLE_CAPABILITY_KEY_EX_CAP || LIBSPDM_ENABLE_CAPABILITY_PSK_EX_CAP)
-    if (m_use_version >= SPDM_MESSAGE_VERSION_11) {
-        if ((m_exe_session & EXE_SESSION_KEY_EX) != 0) {
-            status = do_session_via_spdm(false);
+    /* when use --trans NONE, skip secure session  */
+    if (m_use_transport_layer == SOCKET_TRANSPORT_TYPE_NONE) {
+        if (m_use_version >= SPDM_MESSAGE_VERSION_12) {      
+            status = do_certificate_provising_via_spdm(NULL);
             if (LIBSPDM_STATUS_IS_ERROR(status)) {
-                printf("do_session_via_spdm - %x\n",
-                       (uint32_t)status);
+                    printf("do_certificate_provising_via_spdm - %x\n",
+                        (uint32_t)status);
                 goto done;
-            }
-        }
-
-        if ((m_exe_session & EXE_SESSION_PSK) != 0) {
-            status = do_session_via_spdm(true);
-            if (LIBSPDM_STATUS_IS_ERROR(status)) {
-                printf("do_session_via_spdm - %x\n",
-                       (uint32_t)status);
-                goto done;
-            }
-        }
-        if ((m_exe_session & EXE_SESSION_KEY_EX) != 0) {
-            if (m_use_slot_id == 0) {
-                m_use_slot_id =  1;
-                status = do_session_via_spdm(false);
-                if (LIBSPDM_STATUS_IS_ERROR(status)) {
-                    printf("do_session_via_spdm - %x\n",
-                           (uint32_t)status);
-                    goto done;
-                }
             }
         }
     }
-#endif /*(LIBSPDM_ENABLE_CAPABILITY_KEY_EX_CAP || LIBSPDM_ENABLE_CAPABILITY_PSK_EX_CAP)*/
+    else
+    {
+#if (LIBSPDM_ENABLE_CAPABILITY_KEY_EX_CAP || LIBSPDM_ENABLE_CAPABILITY_PSK_EX_CAP)
+        if (m_use_version >= SPDM_MESSAGE_VERSION_11) {
+            if ((m_exe_session & EXE_SESSION_KEY_EX) != 0) {
+                status = do_session_via_spdm(false);
+                if (LIBSPDM_STATUS_IS_ERROR(status)) {
+                    printf("do_session_via_spdm - %x\n",
+                        (uint32_t)status);
+                    goto done;
+                }
+            }
 
+            if ((m_exe_session & EXE_SESSION_PSK) != 0) {
+                status = do_session_via_spdm(true);
+                if (LIBSPDM_STATUS_IS_ERROR(status)) {
+                    printf("do_session_via_spdm - %x\n",
+                        (uint32_t)status);
+                    goto done;
+                }
+            }
+            if ((m_exe_session & EXE_SESSION_KEY_EX) != 0) {
+                if (m_use_slot_id == 0) {
+                    m_use_slot_id =  1;
+                    status = do_session_via_spdm(false);
+                    if (LIBSPDM_STATUS_IS_ERROR(status)) {
+                        printf("do_session_via_spdm - %x\n",
+                            (uint32_t)status);
+                        goto done;
+                    }
+                }
+            }
+        }
+#endif /*(LIBSPDM_ENABLE_CAPABILITY_KEY_EX_CAP || LIBSPDM_ENABLE_CAPABILITY_PSK_EX_CAP)*/
+    }
     /* Do test - end*/
 
 done:

--- a/spdm_emu/spdm_requester_emu/spdm_requester_session.c
+++ b/spdm_emu/spdm_requester_emu/spdm_requester_session.c
@@ -24,6 +24,7 @@ libspdm_return_t do_measurement_via_spdm(const uint32_t *session_id);
 
 libspdm_return_t pci_doe_process_session_message(void *spdm_context, uint32_t session_id);
 libspdm_return_t mctp_process_session_message(void *spdm_context, uint32_t session_id);
+libspdm_return_t do_certificate_provising_via_spdm(uint32_t* session_id);
 
 libspdm_return_t do_app_session_via_spdm(uint32_t session_id)
 {
@@ -82,21 +83,6 @@ libspdm_return_t do_session_via_spdm(bool use_psk)
     size_t response_size;
     bool result;
     uint32_t response;
-
-#if LIBSPDM_ENABLE_CAPABILITY_GET_CSR_CAP
-    uint8_t csr_form_get[LIBSPDM_MAX_CSR_SIZE];
-    size_t csr_len;
-#endif /*LIBSPDM_ENABLE_CAPABILITY_GET_CSR_CAP*/
-
-#if LIBSPDM_ENABLE_SET_CERTIFICATE_CAP
-    void *cert_chain_to_set;
-    size_t cert_chain_size_to_set;
-    uint8_t slot_id;
-    bool res;
-
-    cert_chain_to_set = NULL;
-    cert_chain_size_to_set = 0;
-#endif /*LIBSPDM_ENABLE_SET_CERTIFICATE_CAP*/
 
     spdm_context = m_spdm_context;
 
@@ -186,65 +172,14 @@ libspdm_return_t do_session_via_spdm(bool use_psk)
     }
 #endif
 
-#if LIBSPDM_ENABLE_CAPABILITY_GET_CSR_CAP
-    /*get csr*/
-    if (m_use_version >= SPDM_MESSAGE_VERSION_12) {
-        csr_len = LIBSPDM_MAX_CSR_SIZE;
-        libspdm_zero_mem(csr_form_get, sizeof(csr_form_get));
-        if ((m_exe_session & EXE_SESSION_GET_CSR) != 0) {
-            status = libspdm_get_csr(spdm_context, NULL, 0, NULL, 0, NULL, csr_form_get,
-                                    &csr_len);
-            if (LIBSPDM_STATUS_IS_ERROR(status)) {
-                printf("libspdm_get_csr - %x\n",
-                        (uint32_t)status);
-            }
+    if (m_use_version >= SPDM_MESSAGE_VERSION_12) {      
+        status = do_certificate_provising_via_spdm(&session_id);
+        if (LIBSPDM_STATUS_IS_ERROR(status)) {
+            printf("do_certificate_provising_via_spdm - %x\n",
+                (uint32_t)status);
+            return status;
         }
-    }    
-#endif /*LIBSPDM_ENABLE_CAPABILITY_GET_CSR_CAP*/
-
-#if LIBSPDM_ENABLE_SET_CERTIFICATE_CAP
-    if (m_use_version >= SPDM_MESSAGE_VERSION_12) {
-        res = libspdm_read_responder_public_certificate_chain(m_use_hash_algo,
-                                                            m_use_asym_algo,
-                                                            &cert_chain_to_set,
-                                                            &cert_chain_size_to_set,
-                                                            NULL, NULL);
-        if (!res) {
-            printf("set certificate :read_responder_public_certificate_chain fail!\n");
-            free(cert_chain_to_set);
-            return LIBSPDM_STATUS_SEND_FAIL;
-        }
-
-        /*set_certificate for slot_id:0 in secure environment*/
-        if ((m_exe_session & EXE_SESSION_SET_CERT) != 0) {
-            slot_id = 0;
-            status = libspdm_set_certificate(spdm_context, slot_id,
-                                            cert_chain_to_set, cert_chain_size_to_set, NULL);
-
-            if (LIBSPDM_STATUS_IS_ERROR(status)) {
-                printf("libspdm_set_certificate - %x\n",
-                        (uint32_t)status);
-            }
-
-        }
-
-        /*set_certificate for slot_id:1 in secure session*/
-        if ((m_exe_session & EXE_SESSION_SET_CERT) != 0) {
-            slot_id = 1;
-            status = libspdm_set_certificate(spdm_context, slot_id,
-                                            cert_chain_to_set, cert_chain_size_to_set, &session_id);
-
-            if (LIBSPDM_STATUS_IS_ERROR(status)) {
-                printf("libspdm_set_certificate - %x\n",
-                        (uint32_t)status);
-            }
-
-        }
-
-        free(cert_chain_to_set);
     }
-#endif /*LIBSPDM_ENABLE_SET_CERTIFICATE_CAP*/
-
 
     if ((m_exe_session & EXE_SESSION_NO_END) == 0) {
         status = libspdm_stop_session(spdm_context, session_id,
@@ -256,6 +191,98 @@ libspdm_return_t do_session_via_spdm(bool use_psk)
     }
 
     return status;
+}
+
+/*
+* These function implements the request and response messages used for provisioning a device with certificate chains.
+* Provisioning of Slot 0 should be only done in a secure environment (such as a secure manufacturing environment)
+*/
+libspdm_return_t do_certificate_provising_via_spdm(uint32_t* session_id)
+{
+    void *spdm_context;
+
+#if LIBSPDM_ENABLE_CAPABILITY_GET_CSR_CAP
+    uint8_t csr_form_get[LIBSPDM_MAX_CSR_SIZE];
+    size_t csr_len;
+#endif /*LIBSPDM_ENABLE_CAPABILITY_GET_CSR_CAP*/
+
+#if LIBSPDM_ENABLE_SET_CERTIFICATE_CAP
+    void *cert_chain_to_set;
+    size_t cert_chain_size_to_set;
+    uint8_t slot_id;
+    bool res;
+
+    cert_chain_to_set = NULL;
+    cert_chain_size_to_set = 0;
+#endif /*LIBSPDM_ENABLE_SET_CERTIFICATE_CAP*/
+
+    libspdm_return_t status;
+    spdm_context = m_spdm_context;
+
+#if LIBSPDM_ENABLE_CAPABILITY_GET_CSR_CAP
+
+    /*get csr*/
+    csr_len = LIBSPDM_MAX_CSR_SIZE;
+    libspdm_zero_mem(csr_form_get, sizeof(csr_form_get));
+    if ((m_exe_session & EXE_SESSION_GET_CSR) != 0) {
+        status = libspdm_get_csr(spdm_context, NULL, 0, NULL, 0, NULL, csr_form_get,
+                                &csr_len);
+        if (LIBSPDM_STATUS_IS_ERROR(status)) {
+            printf("libspdm_get_csr - %x\n",
+                    (uint32_t)status);
+            return status;
+        }
+    }
+ 
+#endif /*LIBSPDM_ENABLE_CAPABILITY_GET_CSR_CAP*/
+
+#if LIBSPDM_ENABLE_SET_CERTIFICATE_CAP
+    res = libspdm_read_responder_public_certificate_chain(m_use_hash_algo,
+                                                        m_use_asym_algo,
+                                                        &cert_chain_to_set,
+                                                        &cert_chain_size_to_set,
+                                                        NULL, NULL);
+    if (!res) {
+        printf("set certificate :read_responder_public_certificate_chain fail!\n");
+        free(cert_chain_to_set);
+        return LIBSPDM_STATUS_INVALID_CERT;
+    }
+
+    /*set_certificate for slot_id:0 in secure environment*/
+    if ((m_exe_session & EXE_SESSION_SET_CERT) != 0) {
+        slot_id = 0;
+        status = libspdm_set_certificate(spdm_context, slot_id,
+                                        cert_chain_to_set, cert_chain_size_to_set, NULL);
+
+        if (LIBSPDM_STATUS_IS_ERROR(status)) {
+            printf("libspdm_set_certificate - %x\n",
+                (uint32_t)status);
+            free(cert_chain_to_set);
+            return status;
+        }
+
+    }
+
+    /*set_certificate for slot_id:1 in secure session*/
+    if (session_id != NULL) {
+        if ((m_exe_session & EXE_SESSION_SET_CERT) != 0) {
+            slot_id = 1;
+            status = libspdm_set_certificate(spdm_context, slot_id,
+                                            cert_chain_to_set, cert_chain_size_to_set, session_id);
+
+            if (LIBSPDM_STATUS_IS_ERROR(status)) {
+                printf("libspdm_set_certificate - %x\n",
+                            (uint32_t)status);
+            }
+
+            free(cert_chain_to_set);
+            return status;
+        }
+    }
+
+    free(cert_chain_to_set);
+#endif /*LIBSPDM_ENABLE_SET_CERTIFICATE_CAP*/ 
+    return LIBSPDM_STATUS_SUCCESS;  
 }
 
 #endif /*(LIBSPDM_ENABLE_CAPABILITY_KEY_EX_CAP || LIBSPDM_ENABLE_CAPABILITY_PSK_EX_CAP)*/


### PR DESCRIPTION
Signed-off-by: BinbinLee <lbbxsxlz@gmail.com>

use option 2(don't send Secure SPDM message if trans is NONE) to fix the bug when use --trans NONE
And remove the code to handle secure sessions in spdm_transport_none_lib.