### PR TITLE
Fix socket lost by using WSACleanup

### DIFF
--- a/spdm_emu/spdm_device_attester_sample/spdm_device_attester_sample.c
+++ b/spdm_emu/spdm_device_attester_sample/spdm_device_attester_sample.c
@@ -92,6 +92,9 @@ bool platform_client_routine(uint16_t port_number)
 #endif
     result = init_client(&platform_socket, port_number);
     if (!result) {
+#ifdef _MSC_VER
+        WSACleanup();
+#endif
         return false;
     }
 

--- a/spdm_emu/spdm_device_validator_sample/spdm_device_validator_sample.c
+++ b/spdm_emu/spdm_device_validator_sample/spdm_device_validator_sample.c
@@ -92,6 +92,9 @@ bool platform_client_routine(uint16_t port_number)
 #endif
     result = init_client(&platform_socket, port_number);
     if (!result) {
+#ifdef _MSC_VER
+        WSACleanup();
+#endif
         return false;
     }
 

--- a/spdm_emu/spdm_requester_emu/spdm_requester_emu.c
+++ b/spdm_emu/spdm_requester_emu/spdm_requester_emu.c
@@ -102,6 +102,9 @@ bool platform_client_routine(uint16_t port_number)
 #endif
     result = init_client(&platform_socket, port_number);
     if (!result) {
+#ifdef _MSC_VER
+        WSACleanup();
+#endif
         return false;
     }
 

--- a/spdm_emu/spdm_responder_emu/spdm_responder_emu.c
+++ b/spdm_emu/spdm_responder_emu/spdm_responder_emu.c
@@ -245,6 +245,9 @@ bool platform_server_routine(uint16_t port_number)
     result = create_socket(port_number, &listen_socket);
     if (!result) {
         printf("Create platform service socket fail\n");
+#ifdef _MSC_VER
+        WSACleanup();
+#endif
         return result;
     }
 


### PR DESCRIPTION
Fix: #130 

An application or DLL is required to perform a successful `WSAStartup` call before it can use Windows Sockets services.

When it has completed the use of Windows Sockets,
the application or DLL must call `WSACleanup` to deregister itself from a
Windows Sockets implementation and allow the implementation to free any
resources allocated on behalf of the application or DLL.

Signed-off-by: Wenxing Hou <wenxing.hou@intel.com>