### PR TITLE
Fix build issues after libspdm refactor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -533,6 +533,7 @@ endif()
     ADD_SUBDIRECTORY(${LIBSPDM_DIR}/os_stub/malloclib out/malloclib.out)
     ADD_SUBDIRECTORY(${LIBSPDM_DIR}/os_stub/spdm_device_secret_lib_sample out/spdm_device_secret_lib_sample.out)
     ADD_SUBDIRECTORY(${LIBSPDM_DIR}/os_stub/platform_lib out/platform_lib.out)
+    ADD_SUBDIRECTORY(${LIBSPDM_DIR}/os_stub/spdm_crypt_ext_lib out/spdm_crypt_ext_lib.out)
 
     ADD_SUBDIRECTORY(library/spdm_transport_none_lib)
     ADD_SUBDIRECTORY(library/mctp_requester_lib)

--- a/spdm_emu/spdm_device_attester_sample/CMakeLists.txt
+++ b/spdm_emu/spdm_device_attester_sample/CMakeLists.txt
@@ -6,6 +6,7 @@ INCLUDE_DIRECTORIES(${PROJECT_SOURCE_DIR}/spdm_emu/spdm_emu_common
                     ${LIBSPDM_DIR}/include
                     ${LIBSPDM_DIR}/include/hal/${ARCH}
                     ${LIBSPDM_DIR}/os_stub/include
+                    ${LIBSPDM_DIR}/os_stub
 )
 
 SET(src_spdm_device_attester_sample
@@ -33,6 +34,7 @@ SET(spdm_device_attester_sample_LIBRARY
     cryptlib_${CRYPTO}
     malloclib
     spdm_crypt_lib
+    spdm_crypt_ext_lib
     spdm_secured_message_lib
     spdm_transport_mctp_lib
     spdm_transport_pcidoe_lib

--- a/spdm_emu/spdm_device_validator_sample/CMakeLists.txt
+++ b/spdm_emu/spdm_device_validator_sample/CMakeLists.txt
@@ -7,6 +7,7 @@ INCLUDE_DIRECTORIES(${PROJECT_SOURCE_DIR}/spdm_emu/spdm_responder_test_client
                     ${LIBSPDM_DIR}/include
                     ${LIBSPDM_DIR}/include/hal/${ARCH}
                     ${LIBSPDM_DIR}/os_stub/include
+                    ${LIBSPDM_DIR}/os_stub
                     ${SPDM_RESPONDER_VALIDATOR_DIR}/include
                     ${COMMON_TEST_FRAMEWORK_DIR}/include
 )
@@ -34,6 +35,7 @@ SET(spdm_device_validator_sample_LIBRARY
     cryptlib_${CRYPTO}
     malloclib
     spdm_crypt_lib
+    spdm_crypt_ext_lib
     spdm_secured_message_lib
     spdm_transport_mctp_lib
     spdm_transport_pcidoe_lib

--- a/spdm_emu/spdm_requester_emu/CMakeLists.txt
+++ b/spdm_emu/spdm_requester_emu/CMakeLists.txt
@@ -7,6 +7,7 @@ INCLUDE_DIRECTORIES(${PROJECT_SOURCE_DIR}/spdm_emu/spdm_requester_emu
                     ${LIBSPDM_DIR}/include
                     ${LIBSPDM_DIR}/include/hal/${ARCH}
                     ${LIBSPDM_DIR}/os_stub/include
+                    ${LIBSPDM_DIR}/os_stub
 )
 
 SET(src_spdm_requester_emu
@@ -35,6 +36,7 @@ SET(spdm_requester_emu_LIBRARY
     cryptlib_${CRYPTO}
     malloclib
     spdm_crypt_lib
+    spdm_crypt_ext_lib
     spdm_secured_message_lib
     spdm_transport_mctp_lib
     spdm_transport_pcidoe_lib

--- a/spdm_emu/spdm_responder_emu/CMakeLists.txt
+++ b/spdm_emu/spdm_responder_emu/CMakeLists.txt
@@ -7,6 +7,7 @@ INCLUDE_DIRECTORIES(${PROJECT_SOURCE_DIR}/spdm_emu/spdm_responder_emu
                     ${LIBSPDM_DIR}/include
                     ${LIBSPDM_DIR}/include/hal/${ARCH}
                     ${LIBSPDM_DIR}/os_stub/include
+                    ${LIBSPDM_DIR}/os_stub
 )
 
 SET(src_spdm_responder_emu
@@ -33,6 +34,7 @@ SET(spdm_responder_emu_LIBRARY
     cryptlib_${CRYPTO}
     malloclib
     spdm_crypt_lib
+    spdm_crypt_ext_lib
     spdm_secured_message_lib
     spdm_transport_mctp_lib
     spdm_transport_pcidoe_lib


### PR DESCRIPTION
libspdm was refactored to bring cryptography functions out of `library/` and into `/os_stub`. spdm-emu needs access to those functions to build properly.

Signed-off-by: Steven Bellock <sbellock@nvidia.com>