### PR TITLE
Add deinit_context when all the flow is over

### DIFF
--- a/spdm_emu/spdm_requester_emu/spdm_requester_emu.c
+++ b/spdm_emu/spdm_requester_emu/spdm_requester_emu.c
@@ -210,6 +210,7 @@ done:
         NULL, 0, &response, &response_size, NULL);
 
     if (m_spdm_context != NULL) {
+        libspdm_deinit_context(m_spdm_context);
         free(m_spdm_context);
         free(m_scratch_buffer);
     }

--- a/spdm_emu/spdm_responder_emu/spdm_responder_emu.c
+++ b/spdm_emu/spdm_responder_emu/spdm_responder_emu.c
@@ -310,6 +310,7 @@ int main(int argc, char *argv[])
     platform_server_routine(DEFAULT_SPDM_PLATFORM_PORT);
 
     if (m_spdm_context != NULL) {
+        libspdm_deinit_context(m_spdm_context);
         free(m_spdm_context);
         free(m_scratch_buffer);
     }


### PR DESCRIPTION
This PR will be merged when the PR https://github.com/DMTF/libspdm/pull/1451 is merged.

And the PR was passed the follow test when the libspdm PR 1451 is merged:
`cmake -E env CFLAGS="-DLIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT=0" cmake -G"NMake Makefiles" -DARCH=x64 -DTOOLCHAIN=VS2019 -DTARGET=Debug -DCRYPTO=mbedtls ..`


Signed-off-by: Wenxing Hou <wenxing.hou@intel.com>