### PR TITLE
Support VERSION_ONLY connection

### DIFF
--- a/doc/spdm_emu.md
+++ b/doc/spdm_emu.md
@@ -18,6 +18,7 @@ This document describes spdm_requester_emu and spdm_responder_emu tool. It can b
          [--aead AES_128_GCM|AES_256_GCM|CHACHA20_POLY1305|SM4_128_GCM]
          [--key_schedule HMAC_HASH]
          [--other_param OPAQUE_FMT_1]
+         [--peer_cap CACHE|CERT|CHAL|MEAS_NO_SIG|MEAS_SIG|MEAS_FRESH|ENCRYPT|MAC|MUT_AUTH|KEY_EX|PSK|PSK_WITH_CONTEXT|ENCAP|HBEAT|KEY_UPD|HANDSHAKE_IN_CLEAR|PUB_KEY_ID|CHUNK|ALIAS_CERT|SET_CERT|CSR|CERT_INSTALL_RESET]
          [--basic_mut_auth NO|BASIC]
          [--mut_auth NO|WO_ENCAP|W_ENCAP|DIGESTS]
          [--meas_sum NO|TCB|ALL]
@@ -53,6 +54,7 @@ This document describes spdm_requester_emu and spdm_responder_emu tool. It can b
                  Above algorithms also support multiple flags. Please use ',' for them.
                  Not all the algorithms are supported, especially SHA3, EDDSA, and SMx.
                  Please don't mix NIST algo with SMx algo.
+         [--peer_cap] is capability flags for the peer. It is used only when --exe_conn has VER_ONLY.
          [--basic_mut_auth] is the basic mutual authentication policy. BASIC is used in CHALLENGE_AUTH. By default, BASIC is used.
          [--mut_auth] is the mutual authentication policy. WO_ENCAP, W_ENCAP or DIGESTS is used in KEY_EXCHANGE_RSP. By default, W_ENCAP is used.
          [--meas_sum] is the measurment summary hash type in CHALLENGE_AUTH, KEY_EXCHANGE_RSP and PSK_EXCHANGE_RSP. By default, ALL is used.
@@ -78,6 +80,9 @@ This document describes spdm_requester_emu and spdm_responder_emu tool. It can b
                  CONTINUE means the requester asks the responder to preserve the current SPDM context.
          [--exe_conn] is used to control the SPDM connection. By default, it is DIGEST,CERT,CHAL,MEAS.
                  VER_ONLY means REQUESTER does not send GET_CAPABILITIES/NEGOTIATE_ALGORITHMS. It is used for quick symmetric authentication with PSK.
+                     The version for responder must be provisioned from ver.
+                     The capablities for local and peer are from cap|peer_cap.
+                     The negotiated algorithms are from hash|meas_spec|meas_hash|asym|req_asym|dhe|aead|key_schedule|other_param and they shall have at most 1 bit set.
                  DIGEST means send GET_DIGESTS command.
                  CERT means send GET_CERTIFICATE command.
                  CHAL means send CHALLENGE command.

--- a/spdm_emu/spdm_emu_common/key.c
+++ b/spdm_emu/spdm_emu_common/key.c
@@ -48,6 +48,7 @@ uint32_t m_use_responder_capability_flags =
      0);
 
 uint32_t m_use_capability_flags = 0;
+uint32_t m_use_peer_capability_flags = 0;
 /*
  * 0
  * 1

--- a/spdm_emu/spdm_emu_common/nv_storage.h
+++ b/spdm_emu/spdm_emu_common/nv_storage.h
@@ -35,6 +35,12 @@ typedef struct {
 #pragma pack()
 
 /**
+ * privision the capability and algorithm for PKS version only case.
+ */
+libspdm_return_t spdm_provision_psk_version_only(void *spdm_context,
+                                                 bool is_requester);
+
+/**
  * Load the negotiated_state from NV storage to an SPDM context.
  */
 libspdm_return_t spdm_load_negotiated_state(void *spdm_context,

--- a/spdm_emu/spdm_emu_common/spdm_emu.h
+++ b/spdm_emu/spdm_emu_common/spdm_emu.h
@@ -27,6 +27,7 @@ extern uint8_t m_use_secured_message_version;
 extern uint32_t m_use_requester_capability_flags;
 extern uint32_t m_use_responder_capability_flags;
 extern uint32_t m_use_capability_flags;
+extern uint32_t m_use_peer_capability_flags;
 
 extern uint8_t m_use_basic_mut_auth;
 extern uint8_t m_use_mut_auth;
@@ -126,5 +127,10 @@ void process_args(char *program_name, int argc, char *argv[]);
 /* expose it because the responder/requester may use it to send/receive other message such as DOE discovery */
 extern uint8_t m_send_receive_buffer[LIBSPDM_SENDER_RECEIVE_BUFFER_SIZE];
 extern size_t m_send_receive_buffer_size;
+
+static inline bool libspdm_onehot0(uint32_t mask)
+{
+    return !mask || !(mask & (mask - 1));
+}
 
 #endif

--- a/spdm_emu/spdm_requester_emu/spdm_requester_spdm.c
+++ b/spdm_emu/spdm_requester_emu/spdm_requester_spdm.c
@@ -327,9 +327,7 @@ void *spdm_client_init(void)
     data_size = sizeof(data32);
     libspdm_get_data(spdm_context, LIBSPDM_DATA_CONNECTION_STATE, &parameter,
                      &data32, &data_size);
-    if(!(m_exe_connection & EXE_CONNECTION_VERSION_ONLY)){
-        LIBSPDM_ASSERT(data32 == LIBSPDM_CONNECTION_STATE_NEGOTIATED);
-    }
+    LIBSPDM_ASSERT(data32 == LIBSPDM_CONNECTION_STATE_NEGOTIATED);
 
     data_size = sizeof(data32);
     libspdm_get_data(spdm_context, LIBSPDM_DATA_MEASUREMENT_HASH_ALGO, &parameter,

--- a/spdm_emu/spdm_requester_emu/spdm_requester_spdm.c
+++ b/spdm_emu/spdm_requester_emu/spdm_requester_spdm.c
@@ -190,7 +190,10 @@ void *spdm_client_init(void)
     libspdm_set_scratch_buffer (spdm_context, m_scratch_buffer, scratch_buffer_size);
 
     if (m_load_state_file_name != NULL) {
-        spdm_load_negotiated_state(spdm_context, true);
+        status = spdm_load_negotiated_state(spdm_context, true);
+        if (LIBSPDM_STATUS_IS_ERROR(status)) {
+            return NULL;
+        }
     }
 
     if (m_use_version != 0) {
@@ -260,6 +263,13 @@ void *spdm_client_init(void)
             free(m_spdm_context);
             m_spdm_context = NULL;
             return NULL;
+        }
+        if ((m_exe_connection & EXE_CONNECTION_VERSION_ONLY) != 0) {
+            /* GET_VERSION is done, handle special PSK use case*/
+            status = spdm_provision_psk_version_only (spdm_context, true);
+            if (LIBSPDM_STATUS_IS_ERROR(status)) {
+                return NULL;
+            }
         }
     }
 


### PR DESCRIPTION
Fix: https://github.com/DMTF/spdm-emu/issues/166

Signed-off-by: Jiewen Yao <jiewen.yao@intel.com>

Test:
```
spdm_responder_emu.exe --exe_conn VER_ONLY --exe_session PSK,MEAS --ver 1.2 --hash SHA_256 --meas_hash SHA_256 --asym RSASSA_2048 --req_asym RSASSA_2048 --dhe FFDHE_2048 --aead AES_128_GCM
spdm_requester_emu.exe --exe_conn VER_ONLY --exe_session PSK,MEAS --ver 1.2 --hash SHA_256 --meas_hash SHA_256 --asym RSASSA_2048 --req_asym RSASSA_2048 --dhe FFDHE_2048 --aead AES_128_GCM
```