### PR TITLE
Change return type and rename libspdm_const_compare_mem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 build
+.vscode/settings.json

--- a/library/pci_tdisp_device_lib_sample/pci_tdisp_device_context.c
+++ b/library/pci_tdisp_device_lib_sample/pci_tdisp_device_context.c
@@ -46,8 +46,8 @@ libtdisp_interface_context *libtdisp_get_interface_context (
     )
 {
     if (libspdm_consttime_is_mem_equal (&g_tdisp_interface_context.interface_id,
-                                   interface_id,
-                                   sizeof(g_tdisp_interface_context.interface_id))) {
+                                        interface_id,
+                                        sizeof(g_tdisp_interface_context.interface_id))) {
         return &g_tdisp_interface_context;
     } else {
         return NULL;

--- a/library/pci_tdisp_device_lib_sample/pci_tdisp_device_context.c
+++ b/library/pci_tdisp_device_lib_sample/pci_tdisp_device_context.c
@@ -16,10 +16,7 @@ libtdisp_interface_context *libtdisp_initialize_interface_context (
     const pci_tdisp_interface_id_t *interface_id
     )
 {
-    libspdm_zero_mem (
-        &g_tdisp_interface_context,
-        sizeof(g_tdisp_interface_context)
-        );
+    libspdm_zero_mem(&g_tdisp_interface_context, sizeof(g_tdisp_interface_context));
     libspdm_copy_mem (
         &g_tdisp_interface_context.interface_id,
         sizeof(g_tdisp_interface_context.interface_id),
@@ -50,7 +47,7 @@ libtdisp_interface_context *libtdisp_get_interface_context (
 {
     if (libspdm_const_compare_mem (&g_tdisp_interface_context.interface_id,
                                    interface_id,
-                                   sizeof(g_tdisp_interface_context.interface_id)) == 0) {
+                                   sizeof(g_tdisp_interface_context.interface_id))) {
         return &g_tdisp_interface_context;
     } else {
         return NULL;

--- a/library/pci_tdisp_device_lib_sample/pci_tdisp_device_context.c
+++ b/library/pci_tdisp_device_lib_sample/pci_tdisp_device_context.c
@@ -45,7 +45,7 @@ libtdisp_interface_context *libtdisp_get_interface_context (
     const pci_tdisp_interface_id_t *interface_id
     )
 {
-    if (libspdm_const_compare_mem (&g_tdisp_interface_context.interface_id,
+    if (libspdm_consttime_is_mem_equal (&g_tdisp_interface_context.interface_id,
                                    interface_id,
                                    sizeof(g_tdisp_interface_context.interface_id))) {
         return &g_tdisp_interface_context;

--- a/library/pci_tdisp_device_lib_sample/pci_tdisp_device_start_interface.c
+++ b/library/pci_tdisp_device_lib_sample/pci_tdisp_device_start_interface.c
@@ -36,7 +36,7 @@ libtdisp_error_code_t pci_tdisp_device_start_interface (const void *pci_doe_cont
         return PCI_TDISP_ERROR_CODE_INVALID_INTERFACE_STATE;
     }
     if (!libspdm_consttime_is_mem_equal (start_interface_nonce, interface_context->start_interface_nonce,
-                                    sizeof(interface_context->start_interface_nonce))) {
+                                         sizeof(interface_context->start_interface_nonce))) {
         return PCI_TDISP_ERROR_CODE_INVALID_NONCE;
     }
 

--- a/library/pci_tdisp_device_lib_sample/pci_tdisp_device_start_interface.c
+++ b/library/pci_tdisp_device_lib_sample/pci_tdisp_device_start_interface.c
@@ -35,8 +35,8 @@ libtdisp_error_code_t pci_tdisp_device_start_interface (const void *pci_doe_cont
     if (interface_context->tdi_state != PCI_TDISP_INTERFACE_STATE_CONFIG_LOCKED) {
         return PCI_TDISP_ERROR_CODE_INVALID_INTERFACE_STATE;
     }
-    if (libspdm_const_compare_mem (start_interface_nonce, interface_context->start_interface_nonce,
-                                   sizeof(interface_context->start_interface_nonce)) != 0) {
+    if (!libspdm_const_compare_mem (start_interface_nonce, interface_context->start_interface_nonce,
+                                    sizeof(interface_context->start_interface_nonce))) {
         return PCI_TDISP_ERROR_CODE_INVALID_NONCE;
     }
 

--- a/library/pci_tdisp_device_lib_sample/pci_tdisp_device_start_interface.c
+++ b/library/pci_tdisp_device_lib_sample/pci_tdisp_device_start_interface.c
@@ -35,7 +35,7 @@ libtdisp_error_code_t pci_tdisp_device_start_interface (const void *pci_doe_cont
     if (interface_context->tdi_state != PCI_TDISP_INTERFACE_STATE_CONFIG_LOCKED) {
         return PCI_TDISP_ERROR_CODE_INVALID_INTERFACE_STATE;
     }
-    if (!libspdm_const_compare_mem (start_interface_nonce, interface_context->start_interface_nonce,
+    if (!libspdm_consttime_is_mem_equal (start_interface_nonce, interface_context->start_interface_nonce,
                                     sizeof(interface_context->start_interface_nonce))) {
         return PCI_TDISP_ERROR_CODE_INVALID_NONCE;
     }

--- a/spdm-device-sample/spdm_device_sample/library/pci_tdisp_device_lib/pci_tdisp_device_context.c
+++ b/spdm-device-sample/spdm_device_sample/library/pci_tdisp_device_lib/pci_tdisp_device_context.c
@@ -50,7 +50,7 @@ libtdisp_interface_context *libtdisp_get_interface_context (
 {
     if (libspdm_const_compare_mem (&g_tdisp_interface_context.interface_id,
                                    interface_id,
-                                   sizeof(g_tdisp_interface_context.interface_id)) == 0) {
+                                   sizeof(g_tdisp_interface_context.interface_id))) {
         return &g_tdisp_interface_context;
     } else {
         return NULL;

--- a/spdm-device-sample/spdm_device_sample/library/pci_tdisp_device_lib/pci_tdisp_device_context.c
+++ b/spdm-device-sample/spdm_device_sample/library/pci_tdisp_device_lib/pci_tdisp_device_context.c
@@ -48,9 +48,9 @@ libtdisp_interface_context *libtdisp_get_interface_context (
     const pci_tdisp_interface_id_t *interface_id
     )
 {
-    if (libspdm_const_compare_mem (&g_tdisp_interface_context.interface_id,
-                                   interface_id,
-                                   sizeof(g_tdisp_interface_context.interface_id))) {
+    if (libspdm_consttime_is_mem_equal (&g_tdisp_interface_context.interface_id,
+                                        interface_id,
+                                        sizeof(g_tdisp_interface_context.interface_id))) {
         return &g_tdisp_interface_context;
     } else {
         return NULL;

--- a/spdm-device-sample/spdm_device_sample/library/pci_tdisp_device_lib/pci_tdisp_device_start_interface.c
+++ b/spdm-device-sample/spdm_device_sample/library/pci_tdisp_device_lib/pci_tdisp_device_start_interface.c
@@ -35,8 +35,8 @@ libtdisp_error_code_t pci_tdisp_device_start_interface (const void *pci_doe_cont
     if (interface_context->tdi_state != PCI_TDISP_INTERFACE_STATE_CONFIG_LOCKED) {
         return PCI_TDISP_ERROR_CODE_INVALID_INTERFACE_STATE;
     }
-    if (libspdm_const_compare_mem (start_interface_nonce, interface_context->start_interface_nonce,
-                                   sizeof(interface_context->start_interface_nonce)) != 0) {
+    if (!libspdm_const_compare_mem (start_interface_nonce, interface_context->start_interface_nonce,
+                                    sizeof(interface_context->start_interface_nonce))) {
         return PCI_TDISP_ERROR_CODE_INVALID_NONCE;
     }
 

--- a/spdm-device-sample/spdm_device_sample/library/pci_tdisp_device_lib/pci_tdisp_device_start_interface.c
+++ b/spdm-device-sample/spdm_device_sample/library/pci_tdisp_device_lib/pci_tdisp_device_start_interface.c
@@ -35,8 +35,8 @@ libtdisp_error_code_t pci_tdisp_device_start_interface (const void *pci_doe_cont
     if (interface_context->tdi_state != PCI_TDISP_INTERFACE_STATE_CONFIG_LOCKED) {
         return PCI_TDISP_ERROR_CODE_INVALID_INTERFACE_STATE;
     }
-    if (!libspdm_const_compare_mem (start_interface_nonce, interface_context->start_interface_nonce,
-                                    sizeof(interface_context->start_interface_nonce))) {
+    if (!libspdm_consttime_is_mem_equal (start_interface_nonce, interface_context->start_interface_nonce,
+                                         sizeof(interface_context->start_interface_nonce))) {
         return PCI_TDISP_ERROR_CODE_INVALID_NONCE;
     }
 

--- a/spdm-device-sample/spdm_device_sample/spdm_device_responder/compiler_stub.c
+++ b/spdm-device-sample/spdm_device_sample/spdm_device_responder/compiler_stub.c
@@ -59,7 +59,7 @@ void *memmove(void *dest, const void *src, size_t count)
 /* Compare bytes in two buffers. */
 int memcmp(const void *buf1, const void *buf2, size_t count)
 {
-    return (int)libspdm_const_compare_mem(buf1, buf2, count);
+    return (int)(libspdm_consttime_is_mem_equal(buf1, buf2, count) ? 0 : 1);
 }
 
 int ascii_strcmp(const char *first_string, const char *second_string)


### PR DESCRIPTION
https://github.com/DMTF/libspdm/pull/1777 changes the return type of `libspdm_const_compare_mem` from `int32_t` to `bool` and renames the function to `libspdm_consttime_is_mem_equal`.

Signed-off-by: Steven Bellock <sbellock@nvidia.com>