### PR TITLE
tdisp: use function_id from request instead of response

### DIFF
--- a/library/pci_tdisp_responder_lib/pci_tdisp_rsp_interface_report.c
+++ b/library/pci_tdisp_responder_lib/pci_tdisp_rsp_interface_report.c
@@ -53,7 +53,7 @@ libspdm_return_t pci_tdisp_get_response_interface_report (const void *pci_doe_co
     interface_report = NULL;
     interface_report_size = 0;
     error_code = pci_tdisp_device_get_interface_report (pci_doe_context, spdm_context, session_id,
-                                                        &tdisp_response->header.interface_id,
+                                                        &tdisp_request->header.interface_id,
                                                         &interface_report, &interface_report_size);
     if (error_code != PCI_TDISP_ERROR_CODE_SUCCESS) {
         return pci_tdisp_get_response_error (pci_doe_context, spdm_context, session_id,

--- a/spdm_emu/spdm_requester_emu/spdm_requester_pci_doe.c
+++ b/spdm_emu/spdm_requester_emu/spdm_requester_pci_doe.c
@@ -137,7 +137,7 @@ libspdm_return_t pci_tdisp_process_session_message(void *spdm_context, uint32_t 
     uint32_t *device_specific_info_len;
     uint8_t *device_specific_info;
 
-    interface_id.function_id = 0;
+    interface_id.function_id = 0xbeef;
     interface_id.reserved = 0;
     status = pci_tdisp_get_version (m_pci_doe_context, spdm_context, &session_id, &interface_id);
     if (LIBSPDM_STATUS_IS_ERROR(status)) {


### PR DESCRIPTION
The value of `interface_id->function_id` in requester is set to 0 and it doesn't catch the bug in `library/pci_tdisp_responder_lib/pci_tdisp_rsp_interface_report.c`.

That is, `tdisp_response->header.interface_id.function_id` is 0 before use and this will cause failure in subsequent check. This PR assigns the correct value to `function_id` before use and set a non-zero value in requester to testify it.

One thing that is worth mentioning is that later on at [pci_tdisp_rsp_interface_report.c#L87](https://github.com/DMTF/spdm-emu/blob/main/library/pci_tdisp_responder_lib/pci_tdisp_rsp_interface_report.c#L87) the response is cleared so fuction_id has to be assigned twice. Or I can move the `libspdm_zero_mem` to the front. What do you think?