### PR TITLE
Revert "github workflows: add uncrustify check"

### DIFF
--- a/.github/workflows/build_CI.yml
+++ b/.github/workflows/build_CI.yml
@@ -18,9 +18,7 @@ jobs:
         # If any *.c *.h *.md file(except:libspdm) have Tab, the check will fail.
       - name: Check code format
         run: |
-          sudo apt install uncrustify -y
-          find . -name "*.c" -o -name "*.h" | uncrustify -c .uncrustify.cfg --check -F -
-          if [ $? -ne 0 ]
+          if grep -rn "	" * --include=*.c --include=*.h --include=*.md;
           then exit 1
           fi
 

--- a/.github/workflows/build_CI_for_slot_id_0xFF.yml
+++ b/.github/workflows/build_CI_for_slot_id_0xFF.yml
@@ -18,12 +18,9 @@ jobs:
         # If any *.c *.h *.md file(except:libspdm) have Tab, the check will fail.
       - name: Check code format
         run: |
-          sudo apt install uncrustify -y
-          find . -name "*.c" -o -name "*.h" | uncrustify -c .uncrustify.cfg --check -F -
-          if [ $? -ne 0 ]
+          if grep -rn "	" * --include=*.c --include=*.h --include=*.md;
           then exit 1
           fi
-
 
   gcc_mbedtls_build:
     runs-on: ubuntu-latest

--- a/.github/workflows/build_CI_for_version1.1.yml
+++ b/.github/workflows/build_CI_for_version1.1.yml
@@ -18,9 +18,7 @@ jobs:
         # If any *.c *.h *.md file(except:libspdm) have Tab, the check will fail.
       - name: Check code format
         run: |
-          sudo apt install uncrustify -y
-          find . -name "*.c" -o -name "*.h" | uncrustify -c .uncrustify.cfg --check -F -
-          if [ $? -ne 0 ]
+          if grep -rn "	" * --include=*.c --include=*.h --include=*.md;
           then exit 1
           fi
 


### PR DESCRIPTION
This reverts commit ac561fbdfc074e239e1115d8103a66fc4c0dbf00.

This solution is not scaleable because it does not display any error message. The submitter has no idea on how to fix.

We need a better solution before enforce that in CI.