### PR TITLE
Revert "github workflows: add uncrustify check"

### DIFF
--- a/.github/workflows/build_CI_FIPS.yml
+++ b/.github/workflows/build_CI_FIPS.yml
@@ -18,9 +18,7 @@ jobs:
         # If any *.c *.h *.md file(except:libspdm) have Tab, the check will fail.
       - name: Check code format
         run: |
-          sudo apt install uncrustify -y
-          find . -name "*.c" -o -name "*.h" | uncrustify -c .uncrustify.cfg --check -F -
-          if [ $? -ne 0 ]
+          if grep -rn "	" * --include=*.c --include=*.h --include=*.md;
           then exit 1
           fi
 


### PR DESCRIPTION
This solution is not scaleable because it does not display any error message. The submitter has no idea on how to fix.

We need a better solution before enforce that in CI.