### PR TITLE
Update to latest libspdm

### DIFF
--- a/spdm_emu/spdm_requester_emu/spdm_requester_measurement.c
+++ b/spdm_emu/spdm_requester_emu/spdm_requester_measurement.c
@@ -10,6 +10,8 @@
 
 extern void *m_spdm_context;
 
+#define LIBSPDM_MAX_MEASUREMENT_EXTENSION_LOG_SIZE 0x1000
+
 /**
  * This function executes SPDM measurement and extend to TPM.
  *
@@ -136,7 +138,7 @@ libspdm_return_t spdm_send_receive_get_measurement(void *spdm_context,
 
             if (measurement_exist_list[index]) {
                 LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "exist measurement index - 0x%x\n", index));
-                
+
                 requester_context[SPDM_REQ_CONTEXT_SIZE - 1] = index;
                 /* get signature in last message only.*/
                 if (received_number_of_block == number_of_blocks - 1) {


### PR DESCRIPTION
- Use libspdm_set_certificate_ex when MULTIKEY_CONN_RSP is true, as the certificate model needs to be specified.
- Define the size of the measurement extension log buffer.

Signed-off-by: Steven Bellock <sbellock@nvidia.com>