### PR TITLE
Add req_slot_id parameter, besides slot_id.

### DIFF
--- a/doc/spdm_emu.md
+++ b/doc/spdm_emu.md
@@ -28,6 +28,7 @@ This document describes spdm_requester_emu and spdm_responder_emu tool. It can b
          [--key_upd REQ|ALL|RSP]
          [--slot_id <0~7|0xFF>]
          [--slot_count <1~8>]
+         [--req_slot_id <0~7|0xFF>]
          [--save_state <NegotiateStateFileName>]
          [--load_state <NegotiateStateFileName>]
          [--exe_mode SHUTDOWN|CONTINUE]
@@ -63,7 +64,8 @@ This document describes spdm_requester_emu and spdm_responder_emu tool. It can b
          [--meas_op] is the measurement operation in GET_MEASUREMENT. By default, ONE_BY_ONE is used.
          [--meas_att] is the measurement attribute in GET_MEASUREMENT. By default, HASH is used.
          [--key_upd] is the key update operation in KEY_UPDATE. By default, ALL is used. RSP will trigger encapsulated KEY_UPDATE.
-         [--slot_id] is to select the peer slot ID in GET_MEASUREMENT, CHALLENGE_AUTH, KEY_EXCHANGE and FINISH. By default, 0 is used.
+         [--slot_id] is to select the responder slot ID in GET_MEASUREMENT, CHALLENGE_AUTH and KEY_EXCHANGE. By default, 0 is used.
+         [--req_slot_id] is to select the requester slot ID in KEY_EXCHANGE_RSP and FINISH. By default, 0 is used.
                  0xFF can be used to indicate provisioned certificate chain. No GET_CERTIFICATE is needed.
          [--slot_count] is to select the local slot count. By default, 3 is used. And the slot store cert chain continuously in emu.
          [--save_state] is to save the current negotiated state to a write-only file.

--- a/spdm_emu/spdm_emu_common/key.c
+++ b/spdm_emu/spdm_emu_common/key.c
@@ -89,6 +89,7 @@ uint8_t m_use_measurement_operation =
 uint8_t m_use_measurement_attribute = 0;
 uint8_t m_use_slot_id = 0;
 uint8_t m_use_slot_count = 3;
+uint8_t m_use_req_slot_id = 0;
 
 /*
  * LIBSPDM_KEY_UPDATE_ACTION_REQUESTER

--- a/spdm_emu/spdm_emu_common/spdm_emu.c
+++ b/spdm_emu/spdm_emu_common/spdm_emu.c
@@ -67,6 +67,7 @@ void print_usage(const char *name)
     printf("   [--key_upd REQ|ALL|RSP]\n");
     printf("   [--slot_id <0~7|0xFF>]\n");
     printf("   [--slot_count <1~8>]\n");
+    printf("   [--req_slot_id <0~7|0xFF>]\n");
     printf("   [--save_state <NegotiateStateFileName>]\n");
     printf("   [--load_state <NegotiateStateFileName>]\n");
     printf("   [--exe_mode SHUTDOWN|CONTINUE]\n");
@@ -119,7 +120,9 @@ void print_usage(const char *name)
     printf(
         "   [--key_upd] is the key update operation in KEY_UPDATE. By default, ALL is used. RSP will trigger encapsulated KEY_UPDATE.\n");
     printf(
-        "   [--slot_id] is to select the peer slot ID in GET_MEASUREMENT, CHALLENGE_AUTH, KEY_EXCHANGE and FINISH. By default, 0 is used.\n");
+        "   [--slot_id] is to select the responder slot ID in GET_MEASUREMENT, CHALLENGE_AUTH and KEY_EXCHANGE. By default, 0 is used.\n");
+    printf(
+        "   [--req_slot_id] is to select the requester slot ID in KEY_EXCHANGE_RSP and FINISH. By default, 0 is used.\n");
     printf(
         "           0xFF can be used to indicate provisioned certificate chain. No GET_CERTIFICATE is needed.\n");
     printf(
@@ -1119,6 +1122,29 @@ void process_args(char *program_name, int argc, char *argv[])
                 continue;
             } else {
                 printf("invalid --slot_count\n");
+                print_usage(program_name);
+                exit(0);
+            }
+        }
+
+        if (strcmp(argv[0], "--req_slot_id") == 0) {
+            if (argc >= 2) {
+                if (!get_value_from_name(
+                        m_slot_id_string_table,
+                        LIBSPDM_ARRAY_SIZE(m_slot_id_string_table),
+                        argv[1], &data32)) {
+                    printf("invalid --req_slot_id %s\n",
+                           argv[1]);
+                    print_usage(program_name);
+                    exit(0);
+                }
+                m_use_req_slot_id = (uint8_t)data32;
+                printf("req_slot_id - 0x%02x\n", m_use_req_slot_id);
+                argc -= 2;
+                argv += 2;
+                continue;
+            } else {
+                printf("invalid --req_slot_id\n");
                 print_usage(program_name);
                 exit(0);
             }

--- a/spdm_emu/spdm_emu_common/spdm_emu.h
+++ b/spdm_emu/spdm_emu_common/spdm_emu.h
@@ -37,6 +37,7 @@ extern uint8_t m_use_measurement_operation;
 extern uint8_t m_use_measurement_attribute;
 extern uint8_t m_use_slot_id;
 extern uint8_t m_use_slot_count;
+extern uint8_t m_use_req_slot_id;
 extern bool g_private_key_mode;
 
 #define ENCAP_KEY_UPDATE 0x8000


### PR DESCRIPTION
Current code only has slot-id controlling both local provision and peer provision. It causes confusing because a platform may support cert chain for local and pub key for peer. It is legal to set slot_id to be 0x0, and req_slot_id to be 0xFF.