### PR TITLE
Fix the error when checking number_of_ckids in cxl_tsp_validate_capability

### DIFF
--- a/library/cxl_tsp_requester_lib/cxl_tsp_req_get_capabilities.c
+++ b/library/cxl_tsp_requester_lib/cxl_tsp_req_get_capabilities.c
@@ -117,7 +117,7 @@ cxl_tsp_validate_capability (
 
     if ((memory_encryption_features_supported & CXL_TSP_MEMORY_ENCRYPTION_FEATURES_SUPPORT_CKID_BASED_ENCRYPTION) != 0) {
         if ((device_capabilities->number_of_ckids < 2) ||
-            (device_capabilities->number_of_ckids > 0x2000)) {
+            (device_capabilities->number_of_ckids >= 0x2000)) {
             return LIBSPDM_STATUS_INVALID_MSG_FIELD;
         }
     }


### PR DESCRIPTION
Fix #393 

According to CXL Spec 3.1 Table 11-32 Get Target Capabilities Response (Sheet 3 of 3) Byte Offset (1Ch):
  Number of CKIDs: Total number of CKIDs that the target supports.
  Valid only if CKID-based Encryption is set in Memory Encryption Features
  Supported. Shall be >=2 and < 2^13.

One of the condition shall be:
  device_capabilities->number_of_ckids >= 0x2000