### PR TITLE
Check "Implicit TE State Change" in cxl_tsp_validate_capability

### DIFF
--- a/library/cxl_tsp_requester_lib/cxl_tsp_req_get_capabilities.c
+++ b/library/cxl_tsp_requester_lib/cxl_tsp_req_get_capabilities.c
@@ -84,6 +84,15 @@ cxl_tsp_validate_capability (
             CXL_TSP_TE_STATE_CHANGE_AND_ACCESS_CONTROL_FEATURES_EXPLICIT_IB_TE_STATE_CHANGE))) == 0)) {
         return LIBSPDM_STATUS_INVALID_MSG_FIELD;
     }
+    supported_explicit_ib_te_state_granularity = device_capabilities->supported_explicit_ib_te_state_granularity;
+    if (((te_state_change_and_access_control_features_supported &
+          CXL_TSP_TE_STATE_CHANGE_AND_ACCESS_CONTROL_FEATURES_IMPLICIT_TE_STATE_CHANGE) != 0) &&
+        (((te_state_change_and_access_control_features_supported &
+           CXL_TSP_TE_STATE_CHANGE_AND_ACCESS_CONTROL_FEATURES_EXPLICIT_IB_TE_STATE_CHANGE) == 0) ||
+         ((supported_explicit_ib_te_state_granularity &
+           CXL_TSP_EXPLICIT_IB_TE_STATE_CHANGE_GRANULARITY_64B) == 0))) {
+        return LIBSPDM_STATUS_INVALID_MSG_FIELD;
+    }
     if (((te_state_change_and_access_control_features_supported &
           CXL_TSP_TE_STATE_CHANGE_AND_ACCESS_CONTROL_FEATURES_EXPLICIT_TE_STATE_CHANGE_SANITIZE) != 0) &&
         (((te_state_change_and_access_control_features_supported &


### PR DESCRIPTION
Fix #395 

According to CXL Spec 3.1 Table 11-32 Get Target Capabilities Response (Sheet 2 of 3) Byte Offset (0Ch):
  Bit[2]: Implicit TE State Change: When set, indicates that the target
  supports implicit TE State changes using a 64B granularity, Explicit
  In-band TE State Change shall be set, and Explicit In-band TE State
  Granularity support for 64B shall be set.

This bit shall be checked in cxl_tsp_validate_capability.