### PR TITLE
tcp: Use discovery functions from libspdm

### DIFF
--- a/spdm_emu/spdm_requester_emu/spdm_requester_tcp.c
+++ b/spdm_emu/spdm_requester_emu/spdm_requester_tcp.c
@@ -12,12 +12,12 @@ SOCKET CreateSocketAndRoleInquiry(SOCKET *sock, uint16_t port_number) {
     uint32_t length;
     char buffer[INET_ADDRSTRLEN];
     uint8_t role_inquiry_buf[sizeof(spdm_tcp_binding_header_t)];
-    spdm_tcp_binding_header_t *tcp_message_header;
+    size_t role_inquiry_size = sizeof(role_inquiry_buf);
     SOCKET requester_socket, incoming_socket;
 
     result = create_socket(port_number, &requester_socket);
     if (!result) {
-        printf("Create platform service socket fail\n");
+        printf("Create platform service socket failed\n");
 #ifdef _MSC_VER
         WSACleanup();
 #endif
@@ -30,7 +30,7 @@ SOCKET CreateSocketAndRoleInquiry(SOCKET *sock, uint16_t port_number) {
                              (socklen_t *)&length);
     if (incoming_socket == INVALID_SOCKET) {
         closesocket(requester_socket);
-        printf("Accept error.  Error is 0x%x\n",
+        printf("Accept error. Error: 0x%x\n",
 #ifdef _MSC_VER
                WSAGetLastError()
 #else
@@ -43,28 +43,30 @@ SOCKET CreateSocketAndRoleInquiry(SOCKET *sock, uint16_t port_number) {
         return INVALID_SOCKET;
     }
 
-    inet_ntop( AF_INET, &peer_address.sin_addr, buffer, sizeof( buffer ));
+    inet_ntop(AF_INET, &peer_address.sin_addr, buffer, sizeof(buffer));
     printf("Connected to peer at: %s\n", buffer);
 
     libspdm_zero_mem(role_inquiry_buf, sizeof(role_inquiry_buf));
     result = read_bytes(incoming_socket, role_inquiry_buf, sizeof(role_inquiry_buf));
-    if(!result) {
+    if (!result) {
         closesocket(requester_socket);
         closesocket(incoming_socket);
-        printf("Failed reading role_inquiry data\n");
+        printf("Failed to read Role-Inquiry data\n");
 #ifdef _MSC_VER
         WSACleanup();
 #endif
         return INVALID_SOCKET;
     }
 
-    tcp_message_header = (spdm_tcp_binding_header_t *) &role_inquiry_buf;
-    if(tcp_message_header->message_type != SPDM_TCP_MESSAGE_TYPE_ROLE_INQUIRY ||
-       tcp_message_header->binding_version != 1 ||
-       tcp_message_header->payload_length != 0) {
+    uint8_t message_type = 0;
+    libspdm_return_t status = libspdm_tcp_decode_discovery_message(
+        role_inquiry_size, role_inquiry_buf, &message_type
+        );
+
+    if (status != LIBSPDM_STATUS_SUCCESS || message_type != SPDM_TCP_MESSAGE_TYPE_ROLE_INQUIRY) {
         closesocket(requester_socket);
         closesocket(incoming_socket);
-        printf("Failed validating role_inquiry data\n");
+        printf("Invalid or unexpected Role-Inquiry message. Status: 0x%x\n", status);
 #ifdef _MSC_VER
         WSACleanup();
 #endif


### PR DESCRIPTION
Use TCP discovery functions from libspdm rather than framing the discovery packets manually.