### PR TITLE
CMakeLists: use debuglib_null for Release builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,6 +122,12 @@ else()
     message(FATAL_ERROR "Unkown build type")
 endif()
 
+if(CMAKE_BUILD_TYPE STREQUAL "Release")
+    set(SPDM_DEBUG_LIB_NAME debuglib_null)
+else()
+    set(SPDM_DEBUG_LIB_NAME debuglib)
+endif()
+
 if(CRYPTO STREQUAL "mbedtls")
     message("CRYPTO = mbedtls")
 elseif(CRYPTO STREQUAL "openssl")

--- a/spdm_emu/spdm_requester_emu/CMakeLists.txt
+++ b/spdm_emu/spdm_requester_emu/CMakeLists.txt
@@ -30,7 +30,7 @@ set(src_spdm_requester_emu
 
 set(spdm_requester_emu_LIBRARY
     memlib
-    debuglib
+    ${SPDM_DEBUG_LIB_NAME}
     spdm_requester_lib
     spdm_common_lib
     ${CRYPTO_LIB_PATHS}

--- a/spdm_emu/spdm_responder_emu/CMakeLists.txt
+++ b/spdm_emu/spdm_responder_emu/CMakeLists.txt
@@ -26,7 +26,7 @@ set(src_spdm_responder_emu
 
 set(spdm_responder_emu_LIBRARY
     memlib
-    debuglib
+    ${SPDM_DEBUG_LIB_NAME}
     spdm_responder_lib
     spdm_common_lib
     ${CRYPTO_LIB_PATHS}


### PR DESCRIPTION
When TARGET=Release is set, debug logs such as SpdmReceiveRequest and SpdmSendResponse are still printed because the executables are hardcoded to link with debuglib. The -DLIBSPDM_DEBUG_ENABLE=0 flag only controls compile-time macros but does not switch the linked debug library implementation.

Add a SPDM_DEBUG_LIB_NAME variable in the main CMakeLists.txt that selects debuglib_null for Release builds and debuglib for Debug builds.