### PR TITLE
Add optional systemd service installation for spdm_responder_emu

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ set(TOOLCHAIN ${TOOLCHAIN} CACHE STRING "Choose the toolchain of build: Windows:
 set(CMAKE_BUILD_TYPE ${TARGET} CACHE STRING "Choose the target of build: Debug Release" FORCE)
 set(CRYPTO ${CRYPTO} CACHE STRING "Choose the crypto of build: mbedtls openssl" FORCE)
 set(GCOV ${GCOV} CACHE STRING "Choose the target of Gcov: ON  OFF, and default is OFF" FORCE)
+option(ENABLE_SYSTEMD "Install systemd service file" OFF)
 
 if(NOT GCOV)
     set(GCOV "OFF")

--- a/README.md
+++ b/README.md
@@ -64,6 +64,44 @@
 
    Please refer to [spdm_emu](https://github.com/DMTF/spdm-emu/blob/main/doc/spdm_emu.md) for detail.
 
+## Systemd Service (Linux)
+
+On Linux systems with systemd, spdm_responder_emu can be installed as a system service. By default, it's disabled.
+
+### Build with systemd support
+```bash
+cmake -DENABLE_SYSTEMD=ON ...
+make
+sudo make install
+```
+
+### Service configuration
+
+The service file is installed to the systemd system unit directory (typically `/lib/systemd/system/`).
+
+Runtime arguments can be configured via environment file:
+```bash
+# /etc/default/spdm-responder-emu
+SPDM_RESPONDER_EMU_ARGS="--trans TCP"
+```
+
+### Service management
+```bash
+# Start the service
+sudo systemctl start spdm-responder-emu
+
+# Enable at boot
+sudo systemctl enable spdm-responder-emu
+
+# Check status
+sudo systemctl status spdm-responder-emu
+
+# View logs
+sudo journalctl -u spdm-responder-emu
+```
+
+**Note:** The service expects certificates in `/usr/share/spdm-emu/`. Ensure sample keys are installed before starting the service.
+
 ## Feature not implemented yet
 
 1) Please refer to [issues](https://github.com/DMTF/spdm-emu/issues) for detail

--- a/spdm_emu/spdm_responder_emu/CMakeLists.txt
+++ b/spdm_emu/spdm_responder_emu/CMakeLists.txt
@@ -102,3 +102,29 @@ if(CMAKE_SYSTEM_NAME MATCHES "Windows" AND NOT TOOLCHAIN STREQUAL "NONE")
         endif()
     endif()
 endif()
+
+if(ENABLE_SYSTEMD)
+    find_package(PkgConfig REQUIRED)
+    pkg_check_modules(SYSTEMD systemd)
+
+    if(SYSTEMD_FOUND)
+        execute_process(
+            COMMAND ${PKG_CONFIG_EXECUTABLE} --variable=systemd_system_unit_dir systemd
+            OUTPUT_VARIABLE SYSTEMD_SYSTEM_UNIT_DIR
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+        )
+
+        if(NOT SYSTEMD_SYSTEM_UNIT_DIR)
+            set(SYSTEMD_SYSTEM_UNIT_DIR "/lib/systemd/system")
+        endif()
+
+        message(STATUS "systemd system unit directory: ${SYSTEMD_SYSTEM_UNIT_DIR}")
+
+        install(
+            FILES ${CMAKE_CURRENT_SOURCE_DIR}/spdm-responder-emu.service
+            DESTINATION ${SYSTEMD_SYSTEM_UNIT_DIR}
+        )
+    else()
+        message(WARNING "ENABLE_SYSTEMD is ON but systemd not found")
+    endif()
+endif()

--- a/spdm_emu/spdm_responder_emu/spdm-responder-emu.service
+++ b/spdm_emu/spdm_responder_emu/spdm-responder-emu.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=SPDM Responder Emulator
+Documentation=https://github.com/DMTF/spdm-emu
+After=network.target
+
+[Service]
+Type=simple
+WorkingDirectory=/usr/share/spdm-emu
+EnvironmentFile=-/etc/default/spdm-responder-emu
+ExecStart=/usr/bin/spdm_responder_emu $SPDM_RESPONDER_EMU_ARGS
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Add ENABLE_SYSTEMD cmake option to install a systemd service file for spdm_responder_emu. This allows Linux distributions using systemd to easily run the SPDM responder emulator as a service. By default, it's disabled and 
won't be installed.

The service file uses WorkingDirectory to ensure the responder can locate certificates via relative paths. An optional environment file (/etc/default/spdm-responder-emu) allows runtime argument configuration.

The systemd unit directory is detected via pkg-config, with a fallback to /lib/systemd/system if not found.

Usage:
  cmake -DENABLE_SYSTEMD=ON ...

Update README.md with systemd service documentation.