### PR TITLE
Add -v/--verbose flag to control trace output

### DIFF
--- a/doc/spdm_emu.md
+++ b/doc/spdm_emu.md
@@ -41,6 +41,7 @@ This document describes spdm_requester_emu and spdm_responder_emu tool. It can b
          [--exe_session KEY_EX|PSK|NO_END|KEY_UPDATE|HEARTBEAT|MEAS|DIGEST|CERT|GET_CSR|SET_CERT|GET_KEY_PAIR_INFO|SET_KEY_PAIR_INFO|EP_INFO|APP]
          [--pcap <PcapFileName>]
          [--priv_key_mode PEM|RAW]
+         [--verbose | -v]
 
       NOTE:
          [--trans] is used to select transport layer message. By default, MCTP is used.
@@ -126,6 +127,7 @@ This document describes spdm_requester_emu and spdm_responder_emu tool. It can b
                  APP means send vendor defined message or application message in session.
          [--pcap] is used to generate PCAP dump file for offline analysis.
          [--priv_key_mode] is used to confirm private key mode with LIBSPDM_PRIVATE_KEY_USE_PEM.
+         [--verbose | -v] is used to enable verbose output. By default, only errors and essential messages are printed. When enabled, detailed platform transport traces and hex dumps are shown.
    ```
 
    Take spdm_requester_emu or spdm_responder_emu as an example, a user may use `spdm_requester_emu --pcap SpdmRequester.pcap > SpdmRequester.log` or `spdm_responder_emu --pcap SpdmResponder.pcap > SpdmResponder.log` to get the PCAP file and the log file.

--- a/spdm_emu/spdm_emu_common/command.c
+++ b/spdm_emu/spdm_emu_common/command.c
@@ -33,14 +33,13 @@ bool read_bytes(const SOCKET socket, uint8_t *buffer,
     while (number_received < number_of_bytes) {
         result = recv(socket, (char *)(buffer + number_received),
                       number_of_bytes - number_received, 0);
-        if (result == -1) {
-            printf("Receive error - 0x%x\n",
+        if (result == -1)
+        {
 #ifdef _MSC_VER
-                   WSAGetLastError()
+            EMU_ERR("Receive error - 0x%x\n", WSAGetLastError());
 #else
-                   errno
+            EMU_ERR("Receive error - 0x%x\n", errno);
 #endif
-                   );
             return false;
         }
         if (result == 0) {
@@ -83,16 +82,16 @@ bool read_multiple_bytes(const SOCKET socket, uint8_t *buffer,
     if (!result) {
         return result;
     }
-    printf("Platform port Receive size: ");
+    EMU_LOG("Platform port Receive size: ");
     length = ntohl(length);
     dump_data((uint8_t *)&length, sizeof(uint32_t));
-    printf("\n");
+    EMU_LOG("\n");
     length = ntohl(length);
 
     *bytes_received = length;
     if (*bytes_received > max_buffer_length) {
-        printf("buffer too small (0x%x). Expected - 0x%x\n",
-               max_buffer_length, *bytes_received);
+        EMU_ERR("buffer too small (0x%x). Expected - 0x%x\n",
+                max_buffer_length, *bytes_received);
         return false;
     }
     if (length == 0) {
@@ -102,9 +101,9 @@ bool read_multiple_bytes(const SOCKET socket, uint8_t *buffer,
     if (!result) {
         return result;
     }
-    printf("Platform port Receive buffer:\n    ");
+    EMU_LOG("Platform port Receive buffer:\n    ");
     dump_data(buffer, length);
-    printf("\n");
+    EMU_LOG("\n");
 
     return true;
 }
@@ -123,22 +122,22 @@ bool receive_platform_data(const SOCKET socket, uint32_t *command,
         return result;
     }
     *command = response;
-    printf("Platform port Receive command: ");
+    EMU_LOG("Platform port Receive command: ");
     response = ntohl(response);
     dump_data((uint8_t *)&response, sizeof(uint32_t));
-    printf("\n");
+    EMU_LOG("\n");
 
     result = read_data32(socket, &transport_type);
     if (!result) {
         return result;
     }
-    printf("Platform port Receive transport_type: ");
+    EMU_LOG("Platform port Receive transport_type: ");
     transport_type = ntohl(transport_type);
     dump_data((uint8_t *)&transport_type, sizeof(uint32_t));
-    printf("\n");
+    EMU_LOG("\n");
     transport_type = ntohl(transport_type);
     if (transport_type != m_use_transport_layer) {
-        printf("transport_type mismatch\n");
+        EMU_ERR("transport_type mismatch\n");
         return false;
     }
 
@@ -198,18 +197,12 @@ bool write_bytes(const SOCKET socket, const uint8_t *buffer,
         if (result == -1) {
 #ifdef _MSC_VER
             if (WSAGetLastError() == 0x2745) {
-                printf("Client disconnected\n");
+                EMU_ERR("Client disconnected\n");
             } else {
-#endif
-            printf("Send error - 0x%x\n",
-#ifdef _MSC_VER
-                   WSAGetLastError()
+                EMU_ERR("Send error - 0x%x\n", WSAGetLastError());
+            }
 #else
-                   errno
-#endif
-                   );
-#ifdef _MSC_VER
-        }
+            EMU_ERR("Send error - 0x%x\n", errno);
 #endif
             return false;
         }
@@ -239,19 +232,19 @@ bool write_multiple_bytes(const SOCKET socket, const uint8_t *buffer,
     if (!result) {
         return result;
     }
-    printf("Platform port Transmit size: ");
+    EMU_LOG("Platform port Transmit size: ");
     bytes_to_send = htonl(bytes_to_send);
     dump_data((uint8_t *)&bytes_to_send, sizeof(uint32_t));
-    printf("\n");
+    EMU_LOG("\n");
     bytes_to_send = htonl(bytes_to_send);
 
     result = write_bytes(socket, buffer, bytes_to_send);
     if (!result) {
         return result;
     }
-    printf("Platform port Transmit buffer:\n    ");
+    EMU_LOG("Platform port Transmit buffer:\n    ");
     dump_data(buffer, bytes_to_send);
-    printf("\n");
+    EMU_LOG("\n");
     return true;
 }
 
@@ -267,19 +260,19 @@ bool send_platform_data(const SOCKET socket, uint32_t command,
     if (!result) {
         return result;
     }
-    printf("Platform port Transmit command: ");
+    EMU_LOG("Platform port Transmit command: ");
     request = htonl(request);
     dump_data((uint8_t *)&request, sizeof(uint32_t));
-    printf("\n");
+    EMU_LOG("\n");
 
     result = write_data32(socket, m_use_transport_layer);
     if (!result) {
         return result;
     }
-    printf("Platform port Transmit transport_type: ");
+    EMU_LOG("Platform port Transmit transport_type: ");
     transport_type = ntohl(m_use_transport_layer);
     dump_data((uint8_t *)&transport_type, sizeof(uint32_t));
-    printf("\n");
+    EMU_LOG("\n");
 
     result = write_multiple_bytes(socket, send_buffer,
                                   (uint32_t)bytes_to_send);

--- a/spdm_emu/spdm_emu_common/spdm_emu.c
+++ b/spdm_emu/spdm_emu_common/spdm_emu.c
@@ -12,6 +12,8 @@
  */
 uint32_t m_exe_mode = EXE_MODE_SHUTDOWN;
 
+bool m_verbose = false;
+
 uint32_t m_exe_connection = (0 |
                              /* EXE_CONNECTION_VERSION_ONLY |*/
                              EXE_CONNECTION_DIGEST | EXE_CONNECTION_CERT |
@@ -81,6 +83,7 @@ void print_usage(const char *name)
     printf("   [--exe_session KEY_EX|PSK|NO_END|KEY_UPDATE|HEARTBEAT|MEAS|MEL|DIGEST|CERT|GET_CSR|SET_CERT|GET_KEY_PAIR_INFO|SET_KEY_PAIR_INFO|EP_INFO|APP]\n");
     printf("   [--pcap <pcap_file_name>]\n");
     printf("   [--priv_key_mode PEM|RAW]\n");
+    printf("   [--verbose | -v]\n");
     printf("\n");
     printf("NOTE:\n");
     printf("   [--trans] is used to select transport layer message. By default, MCTP is used.\n");
@@ -203,6 +206,8 @@ void print_usage(const char *name)
     printf("   [--pcap] is used to generate PCAP dump file for offline analysis.\n");
     printf(
         "   [--priv_key_mode] is uesed to confirm private key mode with LIBSPDM_PRIVATE_KEY_USE_PEM.\n");
+    printf(
+        "   [--verbose | -v] enables additional traces. By default, traces are suppressed.\n");
 }
 
 typedef struct {
@@ -1423,6 +1428,13 @@ void process_args(char *program_name, int argc, char *argv[])
                 print_usage(program_name);
                 exit(0);
             }
+        }
+
+        if (strcmp(argv[0], "--verbose") == 0 || strcmp(argv[0], "-v") == 0) {
+            m_verbose = true;
+            argc--;
+            argv++;
+            continue;
         }
 
         printf("invalid %s\n", argv[0]);

--- a/spdm_emu/spdm_emu_common/spdm_emu.h
+++ b/spdm_emu/spdm_emu_common/spdm_emu.h
@@ -41,6 +41,23 @@ extern uint8_t m_use_req_slot_id;
 extern bool g_private_key_mode;
 extern bool g_start_basic_mut_auth;
 extern uint8_t g_key_exchange_start_mut_auth;
+extern bool m_verbose;
+
+/*
+ * Logging macros for platform trace and error output.
+ *
+ * EMU_LOG:  Guarded by --verbose flag. Used for debug traces.
+ * EMU_INFO: Always prints to stdout. Used for informational status messages.
+ * EMU_ERR:  Always prints to stderr. Used for error conditions.
+ */
+#define EMU_LOG(fmt, ...) \
+    do { if (m_verbose) printf(fmt, ##__VA_ARGS__); } while (0)
+
+#define EMU_INFO(fmt, ...) \
+    printf(fmt, ##__VA_ARGS__)
+
+#define EMU_ERR(fmt, ...) \
+    fprintf(stderr, "ERROR: " fmt, ##__VA_ARGS__)
 
 #define ENCAP_KEY_UPDATE 0x8000
 extern libspdm_key_update_action_t m_use_key_update_action;

--- a/spdm_emu/spdm_emu_common/support.c
+++ b/spdm_emu/spdm_emu_common/support.c
@@ -20,7 +20,7 @@ void dump_data(const uint8_t *buffer, size_t buffer_size)
     size_t index;
 
     for (index = 0; index < buffer_size; index++) {
-        printf("%02x ", buffer[index]);
+        EMU_LOG("%02x ", buffer[index]);
     }
 }
 

--- a/spdm_emu/spdm_requester_emu/spdm_requester_emu.c
+++ b/spdm_emu/spdm_requester_emu/spdm_requester_emu.c
@@ -69,14 +69,14 @@ bool platform_client_routine(uint16_t port_number)
         m_use_tcp_role_inquiry == SOCKET_TCP_ROLE_INQUIRY) {
         m_socket = CreateSocketAndRoleInquiry(&platform_socket, port_number);
         if (m_socket == INVALID_SOCKET) {
-            printf("Create platform service socket fail\n");
+            EMU_ERR("Create platform service socket fail\n");
 #ifdef _MSC_VER
             WSACleanup();
 #endif
             return false;
         }
 
-        printf("Continuing with SPDM flow...\n");
+        EMU_LOG("Continuing with SPDM flow...\n");
     }
     else {
         result = init_client(&platform_socket, port_number);
@@ -108,7 +108,7 @@ bool platform_client_routine(uint16_t port_number)
     if (m_use_transport_layer == SOCKET_TRANSPORT_TYPE_PCI_DOE) {
         status = pci_doe_init_requester ();
         if (LIBSPDM_STATUS_IS_ERROR(status)) {
-            printf("pci_doe_init_requester - %x\n", (uint32_t)status);
+            EMU_ERR("pci_doe_init_requester - %x\n", (uint32_t)status);
             goto done;
         }
     }
@@ -122,7 +122,7 @@ bool platform_client_routine(uint16_t port_number)
 #if (LIBSPDM_ENABLE_CAPABILITY_CERT_CAP && LIBSPDM_ENABLE_CAPABILITY_CHAL_CAP)
     status = do_authentication_via_spdm();
     if (LIBSPDM_STATUS_IS_ERROR(status)) {
-        printf("do_authentication_via_spdm - %x\n", (uint32_t)status);
+        EMU_ERR("do_authentication_via_spdm - %x\n", (uint32_t)status);
         goto done;
     }
 #endif /*(LIBSPDM_ENABLE_CAPABILITY_CERT_CAP && LIBSPDM_ENABLE_CAPABILITY_CHAL_CAP)*/
@@ -131,7 +131,7 @@ bool platform_client_routine(uint16_t port_number)
     if ((m_exe_connection & EXE_CONNECTION_MEAS) != 0) {
         status = do_measurement_via_spdm(NULL);
         if (LIBSPDM_STATUS_IS_ERROR(status)) {
-            printf("do_measurement_via_spdm - %x\n",
+            EMU_ERR("do_measurement_via_spdm - %x\n",
                    (uint32_t)status);
             goto done;
         }
@@ -142,7 +142,7 @@ bool platform_client_routine(uint16_t port_number)
     if (((m_exe_connection & EXE_CONNECTION_MEL) != 0) && (m_use_version >= SPDM_MESSAGE_VERSION_13)) {
         status = do_measurement_mel_via_spdm(NULL);
         if (LIBSPDM_STATUS_IS_ERROR(status)) {
-            printf("do_measurement_mel_via_spdm - %x\n",
+            EMU_ERR("do_measurement_mel_via_spdm - %x\n",
                    (uint32_t)status);
             goto done;
         }
@@ -154,7 +154,7 @@ bool platform_client_routine(uint16_t port_number)
         (m_use_version >= SPDM_MESSAGE_VERSION_13)) {
         status = do_get_endpoint_info_via_spdm(NULL);
         if (LIBSPDM_STATUS_IS_ERROR(status)) {
-            printf("do_get_endpoint_info_via_spdm - %x\n",
+            EMU_ERR("do_get_endpoint_info_via_spdm - %x\n",
                    (uint32_t)status);
             goto done;
         }
@@ -165,12 +165,12 @@ bool platform_client_routine(uint16_t port_number)
             SOCKET_SPDM_COMMAND_OOB_ENCAP_ENDPOINT_INFO, NULL,
             0, &response, &response_size, NULL);
         if (!result) {
-            printf("communicate_platform_data - SOCKET_SPDM_COMMAND_OOB_ENCAP_ENDPOINT_INFO fail\n");
+            EMU_ERR("communicate_platform_data - SOCKET_SPDM_COMMAND_OOB_ENCAP_ENDPOINT_INFO fail\n");
         } else {
             status = libspdm_send_receive_encap_request(
                 m_spdm_context, NULL);
             if (LIBSPDM_STATUS_IS_ERROR(status)) {
-                printf("libspdm_send_receive_encap_request - libspdm_get_endpoint_info - %x\n",
+                EMU_ERR("libspdm_send_receive_encap_request - libspdm_get_endpoint_info - %x\n",
                     (uint32_t)status);
             }
         }
@@ -183,7 +183,7 @@ bool platform_client_routine(uint16_t port_number)
         (m_use_version >= SPDM_MESSAGE_VERSION_13)) {
         status = do_get_key_pair_info_via_spdm(NULL);
         if (LIBSPDM_STATUS_IS_ERROR(status)) {
-            printf("do_get_key_pair_info_via_spdm - %x\n",
+            EMU_ERR("do_get_key_pair_info_via_spdm - %x\n",
                    (uint32_t)status);
             goto done;
         }
@@ -195,7 +195,7 @@ bool platform_client_routine(uint16_t port_number)
         (m_use_version >= SPDM_MESSAGE_VERSION_13)) {
         status = do_set_key_pair_info_via_spdm(NULL);
         if (LIBSPDM_STATUS_IS_ERROR(status)) {
-            printf("do_set_key_pair_info_via_spdm - %x\n",
+            EMU_ERR("do_set_key_pair_info_via_spdm - %x\n",
                    (uint32_t)status);
             goto done;
         }
@@ -207,7 +207,7 @@ bool platform_client_routine(uint16_t port_number)
         if (m_use_version >= SPDM_MESSAGE_VERSION_12) {
             status = do_certificate_provising_via_spdm(NULL);
             if (LIBSPDM_STATUS_IS_ERROR(status)) {
-                printf("do_certificate_provising_via_spdm - %x\n",
+                EMU_ERR("do_certificate_provising_via_spdm - %x\n",
                        (uint32_t)status);
                 goto done;
             }
@@ -220,7 +220,7 @@ bool platform_client_routine(uint16_t port_number)
             if ((m_exe_session & EXE_SESSION_KEY_EX) != 0) {
                 status = do_session_via_spdm(false);
                 if (LIBSPDM_STATUS_IS_ERROR(status)) {
-                    printf("do_session_via_spdm - %x\n",
+                    EMU_ERR("do_session_via_spdm - %x\n",
                            (uint32_t)status);
                     goto done;
                 }
@@ -229,7 +229,7 @@ bool platform_client_routine(uint16_t port_number)
             if ((m_exe_session & EXE_SESSION_PSK) != 0) {
                 status = do_session_via_spdm(true);
                 if (LIBSPDM_STATUS_IS_ERROR(status)) {
-                    printf("do_session_via_spdm - %x\n",
+                    EMU_ERR("do_session_via_spdm - %x\n",
                            (uint32_t)status);
                     goto done;
                 }
@@ -239,7 +239,7 @@ bool platform_client_routine(uint16_t port_number)
                     m_use_slot_id = m_other_slot_id;
                     status = do_session_via_spdm(false);
                     if (LIBSPDM_STATUS_IS_ERROR(status)) {
-                        printf("do_session_via_spdm - %x\n",
+                        EMU_ERR("do_session_via_spdm - %x\n",
                                (uint32_t)status);
                         goto done;
                     }
@@ -288,10 +288,10 @@ done:
 int main(int argc, char *argv[])
 {
     bool result;
-    printf("%s version 0.1\n", "spdm_requester_emu");
     srand((unsigned int)time(NULL));
 
     process_args("spdm_requester_emu", argc, argv);
+    EMU_LOG("%s version 0.1\n", "spdm_requester_emu");
 
     if (m_use_transport_layer == SOCKET_TRANSPORT_TYPE_TCP) {
         /* Port number 4194 for SPDM */
@@ -301,7 +301,7 @@ int main(int argc, char *argv[])
         result = platform_client_routine(DEFAULT_SPDM_PLATFORM_PORT);
     }
 
-    printf("Client stopped\n");
+    EMU_INFO("Client stopped\n");
 
     close_pcap_packet_file();
     return (!result);

--- a/spdm_emu/spdm_requester_emu/spdm_requester_pci_doe.c
+++ b/spdm_emu/spdm_requester_emu/spdm_requester_pci_doe.c
@@ -30,7 +30,7 @@ libspdm_return_t pci_doe_init_requester()
 
     for (index = 0; index < data_object_protocol_size/sizeof(pci_doe_data_object_protocol_t);
          index++) {
-        printf("DOE(0x%x) VendorId-0x%04x, DataObjectType-0x%02x\n",
+        EMU_INFO("DOE(0x%x) VendorId-0x%04x, DataObjectType-0x%02x\n",
                index, data_object_protocol[index].vendor_id,
                data_object_protocol[index].data_object_type);
     }
@@ -740,20 +740,20 @@ libspdm_return_t do_cxl_tsp_2nd_session_via_spdm(void *spdm_context, size_t inde
                                    m_use_slot_id, m_session_policy, &session_id,
                                    &heartbeat_period, measurement_hash);
     if (LIBSPDM_STATUS_IS_ERROR(status)) {
-        printf("libspdm_start_session(2nd) - %x\n", (uint32_t)status);
+        EMU_ERR("libspdm_start_session(2nd) - %x\n", (uint32_t)status);
         return status;
     }
 
     status = cxl_tsp_process_session_message (spdm_context, session_id, LIB_CXL_TSP_SESSION_TYPE_SECONDARY);
     if (LIBSPDM_STATUS_IS_ERROR(status)) {
-        printf("do_app_session_via_spdm(2nd) - %x\n", (uint32_t)status);
+        EMU_ERR("do_app_session_via_spdm(2nd) - %x\n", (uint32_t)status);
         return status;
     }
 
     status = libspdm_stop_session(spdm_context, session_id,
                                   m_end_session_attributes);
     if (LIBSPDM_STATUS_IS_ERROR(status)) {
-        printf("libspdm_stop_session(2nd) - %x\n", (uint32_t)status);
+        EMU_ERR("libspdm_stop_session(2nd) - %x\n", (uint32_t)status);
         return status;
     }
 

--- a/spdm_emu/spdm_requester_emu/spdm_requester_session.c
+++ b/spdm_emu/spdm_requester_emu/spdm_requester_session.c
@@ -113,14 +113,14 @@ libspdm_return_t do_session_via_spdm(bool use_psk)
                                    m_use_slot_id, m_session_policy, &session_id,
                                    &heartbeat_period, measurement_hash);
     if (LIBSPDM_STATUS_IS_ERROR(status)) {
-        printf("libspdm_start_session - %x\n", (uint32_t)status);
+        EMU_ERR("libspdm_start_session - %x\n", (uint32_t)status);
         return status;
     }
 
     if ((m_exe_session & EXE_SESSION_APP) != 0) {
         status = do_app_session_via_spdm(session_id);
         if (LIBSPDM_STATUS_IS_ERROR(status)) {
-            printf("do_app_session_via_spdm - %x\n", (uint32_t)status);
+            EMU_ERR("do_app_session_via_spdm - %x\n", (uint32_t)status);
             return status;
         }
     }
@@ -128,7 +128,7 @@ libspdm_return_t do_session_via_spdm(bool use_psk)
     if ((m_exe_session & EXE_SESSION_HEARTBEAT) != 0) {
         status = libspdm_heartbeat(spdm_context, session_id);
         if (LIBSPDM_STATUS_IS_ERROR(status)) {
-            printf("libspdm_heartbeat - %x\n", (uint32_t)status);
+            EMU_ERR("libspdm_heartbeat - %x\n", (uint32_t)status);
         }
     }
 
@@ -138,7 +138,7 @@ libspdm_return_t do_session_via_spdm(bool use_psk)
             status =
                 libspdm_key_update(spdm_context, session_id, true);
             if (LIBSPDM_STATUS_IS_ERROR(status)) {
-                printf("libspdm_key_update - %x\n",
+                EMU_ERR("libspdm_key_update - %x\n",
                        (uint32_t)status);
             }
             break;
@@ -147,7 +147,7 @@ libspdm_return_t do_session_via_spdm(bool use_psk)
             status = libspdm_key_update(spdm_context, session_id,
                                         false);
             if (LIBSPDM_STATUS_IS_ERROR(status)) {
-                printf("libspdm_key_update - %x\n",
+                EMU_ERR("libspdm_key_update - %x\n",
                        (uint32_t)status);
             }
             break;
@@ -159,13 +159,13 @@ libspdm_return_t do_session_via_spdm(bool use_psk)
                 SOCKET_SPDM_COMMAND_OOB_ENCAP_KEY_UPDATE, (const uint8_t *)&session_id,
                 sizeof(session_id), &response, &response_size, NULL);
             if (!result) {
-                printf("communicate_platform_data - SOCKET_SPDM_COMMAND_OOB_ENCAP_KEY_UPDATE fail\n");
+                EMU_ERR("communicate_platform_data - SOCKET_SPDM_COMMAND_OOB_ENCAP_KEY_UPDATE fail\n");
             } else {
 #if (LIBSPDM_ENABLE_CAPABILITY_MUT_AUTH_CAP) || (LIBSPDM_ENABLE_CAPABILITY_ENCAP_CAP)
                 status = libspdm_send_receive_encap_request(
                     spdm_context, &session_id);
                 if (LIBSPDM_STATUS_IS_ERROR(status)) {
-                    printf("libspdm_send_receive_encap_request - libspdm_key_update - %x\n",
+                    EMU_ERR("libspdm_send_receive_encap_request - libspdm_key_update - %x\n",
                            (uint32_t)status);
                 }
 #endif
@@ -182,7 +182,7 @@ libspdm_return_t do_session_via_spdm(bool use_psk)
     if ((m_exe_session & EXE_SESSION_MEAS) != 0) {
         status = do_measurement_via_spdm(&session_id);
         if (LIBSPDM_STATUS_IS_ERROR(status)) {
-            printf("do_measurement_via_spdm - %x\n",
+            EMU_ERR("do_measurement_via_spdm - %x\n",
                    (uint32_t)status);
         }
     }
@@ -192,7 +192,7 @@ libspdm_return_t do_session_via_spdm(bool use_psk)
     if (((m_exe_session & EXE_SESSION_MEL) != 0) && (m_use_version >= SPDM_MESSAGE_VERSION_13)) {
         status = do_measurement_mel_via_spdm(&session_id);
         if (LIBSPDM_STATUS_IS_ERROR(status)) {
-            printf("do_measurement_mel_via_spdm - %x\n",
+            EMU_ERR("do_measurement_mel_via_spdm - %x\n",
                    (uint32_t)status);
         }
     }
@@ -203,7 +203,7 @@ libspdm_return_t do_session_via_spdm(bool use_psk)
         (m_use_version >= SPDM_MESSAGE_VERSION_13)) {
         status = do_get_endpoint_info_via_spdm(&session_id);
         if (LIBSPDM_STATUS_IS_ERROR(status)) {
-            printf("do_get_endpoint_info_via_spdm - %x\n",
+            EMU_ERR("do_get_endpoint_info_via_spdm - %x\n",
                    (uint32_t)status);
         }
 
@@ -214,12 +214,12 @@ libspdm_return_t do_session_via_spdm(bool use_psk)
             SOCKET_SPDM_COMMAND_OOB_ENCAP_ENDPOINT_INFO, NULL,
             0, &response, &response_size, NULL);
         if (!result) {
-            printf("communicate_platform_data - SOCKET_SPDM_COMMAND_OOB_ENCAP_ENDPOINT_INFO fail\n");
+            EMU_ERR("communicate_platform_data - SOCKET_SPDM_COMMAND_OOB_ENCAP_ENDPOINT_INFO fail\n");
         } else {
             status = libspdm_send_receive_encap_request(
                 spdm_context, &session_id);
             if (LIBSPDM_STATUS_IS_ERROR(status)) {
-                printf("libspdm_send_receive_encap_request - libspdm_get_endpoint_info - %x\n",
+                EMU_ERR("libspdm_send_receive_encap_request - libspdm_get_endpoint_info - %x\n",
                     (uint32_t)status);
             }
         }
@@ -232,7 +232,7 @@ libspdm_return_t do_session_via_spdm(bool use_psk)
         (m_use_version >= SPDM_MESSAGE_VERSION_13)) {
         status = do_get_key_pair_info_via_spdm(&session_id);
         if (LIBSPDM_STATUS_IS_ERROR(status)) {
-            printf("do_get_key_pair_info_via_spdm - %x\n",
+            EMU_ERR("do_get_key_pair_info_via_spdm - %x\n",
                    (uint32_t)status);
         }
     }
@@ -243,7 +243,7 @@ libspdm_return_t do_session_via_spdm(bool use_psk)
         (m_use_version >= SPDM_MESSAGE_VERSION_13)) {
         status = do_set_key_pair_info_via_spdm(&session_id);
         if (LIBSPDM_STATUS_IS_ERROR(status)) {
-            printf("do_set_key_pair_info_via_spdm - %x\n",
+            EMU_ERR("do_set_key_pair_info_via_spdm - %x\n",
                    (uint32_t)status);
         }
     }
@@ -252,7 +252,7 @@ libspdm_return_t do_session_via_spdm(bool use_psk)
 #if (LIBSPDM_ENABLE_CAPABILITY_CERT_CAP && LIBSPDM_ENABLE_CAPABILITY_CHAL_CAP)
     status = get_digest_cert_in_session(&session_id);
     if (LIBSPDM_STATUS_IS_ERROR(status)) {
-        printf("get_digest_cert_in_session - %x\n",
+        EMU_ERR("get_digest_cert_in_session - %x\n",
                (uint32_t)status);
     }
 #endif
@@ -260,7 +260,7 @@ libspdm_return_t do_session_via_spdm(bool use_psk)
     if (m_use_version >= SPDM_MESSAGE_VERSION_12) {
         status = do_certificate_provising_via_spdm(&session_id);
         if (LIBSPDM_STATUS_IS_ERROR(status)) {
-            printf("do_certificate_provising_via_spdm - %x\n",
+            EMU_ERR("do_certificate_provising_via_spdm - %x\n",
                    (uint32_t)status);
             return status;
         }
@@ -270,7 +270,7 @@ libspdm_return_t do_session_via_spdm(bool use_psk)
         status = libspdm_stop_session(spdm_context, session_id,
                                       m_end_session_attributes);
         if (LIBSPDM_STATUS_IS_ERROR(status)) {
-            printf("libspdm_stop_session - %x\n", (uint32_t)status);
+            EMU_ERR("libspdm_stop_session - %x\n", (uint32_t)status);
             return status;
         }
     }
@@ -342,7 +342,7 @@ libspdm_return_t do_certificate_provising_via_spdm(uint32_t* session_id)
 #endif /*LIBSPDM_ENABLE_CAPABILITY_CSR_CAP_EX*/
         }
         if (LIBSPDM_STATUS_IS_ERROR(status)) {
-            printf("libspdm_get_csr - %x\n", (uint32_t)status);
+            EMU_ERR("libspdm_get_csr - %x\n", (uint32_t)status);
             return status;
         }
     }
@@ -390,7 +390,7 @@ libspdm_return_t do_certificate_provising_via_spdm(uint32_t* session_id)
     }
     if ((m_use_asym_algo != 0) || (m_use_pqc_asym_algo != 0)) {
         if (!res) {
-            printf("set certificate :read_responder_public_certificate_chain fail!\n");
+            EMU_ERR("set certificate :read_responder_public_certificate_chain fail!\n");
             free(cert_chain_to_set);
             return LIBSPDM_STATUS_INVALID_CERT;
         }
@@ -410,7 +410,7 @@ libspdm_return_t do_certificate_provising_via_spdm(uint32_t* session_id)
                                              cert_chain_to_set, cert_chain_size_to_set);
         }
         if (LIBSPDM_STATUS_IS_ERROR(status)) {
-            printf("libspdm_set_certificate - %x\n",
+            EMU_ERR("libspdm_set_certificate - %x\n",
                    (uint32_t)status);
             free(cert_chain_to_set);
             return status;
@@ -435,7 +435,7 @@ libspdm_return_t do_certificate_provising_via_spdm(uint32_t* session_id)
                 }
 
                 if (LIBSPDM_STATUS_IS_ERROR(status)) {
-                    printf("libspdm_set_certificate - %x\n",
+                    EMU_ERR("libspdm_set_certificate - %x\n",
                         (uint32_t)status);
                 }
 

--- a/spdm_emu/spdm_requester_emu/spdm_requester_spdm.c
+++ b/spdm_emu/spdm_requester_emu/spdm_requester_spdm.c
@@ -24,26 +24,22 @@ bool communicate_platform_data(SOCKET socket, uint32_t command,
     result =
         send_platform_data(socket, command, send_buffer, bytes_to_send);
     if (!result) {
-        printf("send_platform_data Error - %x\n",
 #ifdef _MSC_VER
-               WSAGetLastError()
+        EMU_ERR("send_platform_data Error - %x\n", WSAGetLastError());
 #else
-               errno
+        EMU_ERR("send_platform_data Error - %x\n", errno);
 #endif
-               );
         return result;
     }
 
     result = receive_platform_data(socket, response, receive_buffer,
                                    bytes_to_receive);
     if (!result) {
-        printf("receive_platform_data Error - %x\n",
 #ifdef _MSC_VER
-               WSAGetLastError()
+        EMU_ERR("receive_platform_data Error - %x\n", WSAGetLastError());
 #else
-               errno
+        EMU_ERR("receive_platform_data Error - %x\n", errno);
 #endif
-               );
         return result;
     }
     return result;
@@ -58,13 +54,11 @@ libspdm_return_t spdm_device_send_message(void *spdm_context,
     result = send_platform_data(m_socket, SOCKET_SPDM_COMMAND_NORMAL,
                                 request, (uint32_t)request_size);
     if (!result) {
-        printf("send_platform_data Error - %x\n",
 #ifdef _MSC_VER
-               WSAGetLastError()
+        EMU_ERR("send_platform_data Error - %x\n", WSAGetLastError());
 #else
-               errno
+        EMU_ERR("send_platform_data Error - %x\n", errno);
 #endif
-               );
         return LIBSPDM_STATUS_SEND_FAIL;
     }
     return LIBSPDM_STATUS_SUCCESS;
@@ -81,13 +75,11 @@ libspdm_return_t spdm_device_receive_message(void *spdm_context,
     result = receive_platform_data(m_socket, &command, *response,
                                    response_size);
     if (!result) {
-        printf("receive_platform_data Error - %x\n",
 #ifdef _MSC_VER
-               WSAGetLastError()
+        EMU_ERR("receive_platform_data Error - %x\n", WSAGetLastError());
 #else
-               errno
+        EMU_ERR("receive_platform_data Error - %x\n", errno);
 #endif
-               );
         return LIBSPDM_STATUS_RECEIVE_FAIL;
     }
     return LIBSPDM_STATUS_SUCCESS;
@@ -155,7 +147,7 @@ void *spdm_client_init(void)
     uint32_t responder_capabilities_flag;
     uint32_t max_spdm_msg_size;
 
-    printf("context_size - 0x%x\n", (uint32_t)libspdm_get_context_size());
+    EMU_LOG("context_size - 0x%x\n", (uint32_t)libspdm_get_context_size());
 
     m_spdm_context = (void *)malloc(libspdm_get_context_size());
     if (m_spdm_context == NULL) {
@@ -341,7 +333,7 @@ void *spdm_client_init(void)
             spdm_context,
             (m_exe_connection & EXE_CONNECTION_VERSION_ONLY) != 0);
         if (LIBSPDM_STATUS_IS_ERROR(status)) {
-            printf("libspdm_init_connection - 0x%x\n", (uint32_t)status);
+            EMU_ERR("libspdm_init_connection - 0x%x\n", (uint32_t)status);
             free(m_spdm_context);
             m_spdm_context = NULL;
             return NULL;
@@ -486,8 +478,8 @@ void *spdm_client_init(void)
         m_exe_session &= ~EXE_SESSION_EP_INFO;
     }
 
-    printf("slot_id - %x\n", m_use_slot_id);
-    printf("req_slot_id - %x\n", m_use_req_slot_id);
+    EMU_LOG("slot_id - %x\n", m_use_slot_id);
+    EMU_LOG("req_slot_id - %x\n", m_use_req_slot_id);
 
     if (m_use_slot_id == 0xFF) {
         if (m_use_asym_algo != 0) {
@@ -505,7 +497,7 @@ void *spdm_client_init(void)
                                  &parameter, data, data_size);
                 /* Do not free it.*/
             } else {
-                printf("read_responder_public_key fail!\n");
+                EMU_ERR("read_responder_public_key fail!\n");
                 free(m_spdm_context);
                 m_spdm_context = NULL;
                 return NULL;
@@ -537,7 +529,7 @@ void *spdm_client_init(void)
                                 &parameter, (void *)root_cert, root_cert_size);
                 /* Do not free it.*/
             } else {
-                printf("read_responder_root_public_certificate fail!\n");
+                EMU_ERR("read_responder_root_public_certificate fail!\n");
                 free(m_spdm_context);
                 m_spdm_context = NULL;
                 return NULL;
@@ -570,7 +562,7 @@ void *spdm_client_init(void)
                                 &parameter, (void *)root_cert1, root_cert1_size);
                 /* Do not free it.*/
             } else {
-                printf("read_responder_root_public_certificate fail!\n");
+                EMU_ERR("read_responder_root_public_certificate fail!\n");
                 free(m_spdm_context);
                 m_spdm_context = NULL;
                 return NULL;
@@ -594,7 +586,7 @@ void *spdm_client_init(void)
                                  &parameter, data, data_size);
                 /* Do not free it.*/
             } else {
-                printf("read_requester_public_key fail!\n");
+                EMU_ERR("read_requester_public_key fail!\n");
                 free(m_spdm_context);
                 m_spdm_context = NULL;
                 return NULL;
@@ -641,7 +633,7 @@ void *spdm_client_init(void)
                 }
                 /* do not free it*/
             } else {
-                printf("read_requester_public_certificate_chain fail!\n");
+                EMU_ERR("read_requester_public_certificate_chain fail!\n");
                 free(m_spdm_context);
                 m_spdm_context = NULL;
                 return NULL;

--- a/spdm_emu/spdm_requester_emu/spdm_requester_tcp.c
+++ b/spdm_emu/spdm_requester_emu/spdm_requester_tcp.c
@@ -17,26 +17,24 @@ SOCKET CreateSocketAndRoleInquiry(SOCKET *sock, uint16_t port_number) {
 
     result = create_socket(port_number, &requester_socket);
     if (!result) {
-        printf("Create platform service socket failed\n");
+        EMU_ERR("Create platform service socket failed\n");
 #ifdef _MSC_VER
         WSACleanup();
 #endif
         return INVALID_SOCKET;
     }
 
-    printf("Platform server listening on port %d\n", port_number);
+    EMU_LOG("Platform server listening on port %d\n", port_number);
     length = sizeof(peer_address);
     incoming_socket = accept(requester_socket, (struct sockaddr *)&peer_address,
                              (socklen_t *)&length);
     if (incoming_socket == INVALID_SOCKET) {
         closesocket(requester_socket);
-        printf("Accept error. Error: 0x%x\n",
 #ifdef _MSC_VER
-               WSAGetLastError()
+        EMU_ERR("Accept error. Error: 0x%x\n", WSAGetLastError());
 #else
-               errno
+        EMU_ERR("Accept error. Error: 0x%x\n", errno);
 #endif
-               );
 #ifdef _MSC_VER
         WSACleanup();
 #endif
@@ -44,14 +42,14 @@ SOCKET CreateSocketAndRoleInquiry(SOCKET *sock, uint16_t port_number) {
     }
 
     inet_ntop(AF_INET, &peer_address.sin_addr, buffer, sizeof(buffer));
-    printf("Connected to peer at: %s\n", buffer);
+    EMU_LOG("Connected to peer at: %s\n", buffer);
 
     libspdm_zero_mem(role_inquiry_buf, sizeof(role_inquiry_buf));
     result = read_bytes(incoming_socket, role_inquiry_buf, sizeof(role_inquiry_buf));
     if (!result) {
         closesocket(requester_socket);
         closesocket(incoming_socket);
-        printf("Failed to read Role-Inquiry data\n");
+        EMU_ERR("Failed to read Role-Inquiry data\n");
 #ifdef _MSC_VER
         WSACleanup();
 #endif
@@ -66,7 +64,7 @@ SOCKET CreateSocketAndRoleInquiry(SOCKET *sock, uint16_t port_number) {
     if (status != LIBSPDM_STATUS_SUCCESS || message_type != SPDM_TCP_MESSAGE_TYPE_ROLE_INQUIRY) {
         closesocket(requester_socket);
         closesocket(incoming_socket);
-        printf("Invalid or unexpected Role-Inquiry message. Status: 0x%x\n", status);
+        EMU_ERR("Invalid or unexpected Role-Inquiry message. Status: 0x%x\n", status);
 #ifdef _MSC_VER
         WSACleanup();
 #endif

--- a/spdm_emu/spdm_responder_emu/spdm_responder_emu.c
+++ b/spdm_emu/spdm_responder_emu/spdm_responder_emu.c
@@ -37,7 +37,7 @@ bool platform_server(const SOCKET socket)
         }
         if ((status == LIBSPDM_STATUS_SEND_FAIL) ||
             (status == LIBSPDM_STATUS_RECEIVE_FAIL)) {
-            printf("Server Critical Error - STOP\n");
+            EMU_ERR("Server Critical Error - STOP\n");
             return false;
         }
         if (status != LIBSPDM_STATUS_UNSUPPORTED_CAP) {
@@ -50,13 +50,11 @@ bool platform_server(const SOCKET socket)
                                         (uint8_t *)"Server Hello!",
                                         sizeof("Server Hello!"));
             if (!result) {
-                printf("send_platform_data Error - %x\n",
 #ifdef _MSC_VER
-                       WSAGetLastError()
+                EMU_ERR("send_platform_data Error - %x\n", WSAGetLastError());
 #else
-                       errno
+                EMU_ERR("send_platform_data Error - %x\n", errno);
 #endif
-                       );
                 return true;
             }
             break;
@@ -74,13 +72,11 @@ bool platform_server(const SOCKET socket)
                 SOCKET_SPDM_COMMAND_OOB_ENCAP_KEY_UPDATE, NULL,
                 0);
             if (!result) {
-                printf("send_platform_data Error - %x\n",
 #ifdef _MSC_VER
-                       WSAGetLastError()
+                EMU_ERR("send_platform_data Error - %x\n", WSAGetLastError());
 #else
-                       errno
+                EMU_ERR("send_platform_data Error - %x\n", errno);
 #endif
-                       );
                 return true;
             }
 #endif
@@ -94,13 +90,11 @@ bool platform_server(const SOCKET socket)
                 SOCKET_SPDM_COMMAND_OOB_ENCAP_ENDPOINT_INFO, NULL,
                 0);
             if (!result) {
-                printf("send_platform_data Error - %x\n",
 #ifdef _MSC_VER
-                       WSAGetLastError()
+                EMU_ERR("send_platform_data Error - %x\n", WSAGetLastError());
 #else
-                       errno
+                EMU_ERR("send_platform_data Error - %x\n", errno);
 #endif
-                       );
                 return true;
             }
 #endif /*(LIBSPDM_ENABLE_CAPABILITY_ENDPOINT_INFO_CAP) || (LIBSPDM_ENABLE_CAPABILITY_ENCAP_CAP)*/
@@ -110,13 +104,11 @@ bool platform_server(const SOCKET socket)
             result = send_platform_data(
                 socket, SOCKET_SPDM_COMMAND_SHUTDOWN, NULL, 0);
             if (!result) {
-                printf("send_platform_data Error - %x\n",
 #ifdef _MSC_VER
-                       WSAGetLastError()
+                EMU_ERR("send_platform_data Error - %x\n", WSAGetLastError());
 #else
-                       errno
+                EMU_ERR("send_platform_data Error - %x\n", errno);
 #endif
-                       );
                 return true;
             }
             return false;
@@ -126,13 +118,11 @@ bool platform_server(const SOCKET socket)
             result = send_platform_data(
                 socket, SOCKET_SPDM_COMMAND_CONTINUE, NULL, 0);
             if (!result) {
-                printf("send_platform_data Error - %x\n",
 #ifdef _MSC_VER
-                       WSAGetLastError()
+                EMU_ERR("send_platform_data Error - %x\n", WSAGetLastError());
 #else
-                       errno
+                EMU_ERR("send_platform_data Error - %x\n", errno);
 #endif
-                       );
                 return true;
             }
             return true;
@@ -154,13 +144,11 @@ bool platform_server(const SOCKET socket)
                     socket, SOCKET_SPDM_COMMAND_NORMAL,
                     response, response_size);
                 if (!result) {
-                    printf("send_platform_data Error - %x\n",
 #ifdef _MSC_VER
-                           WSAGetLastError()
+                    EMU_ERR("send_platform_data Error - %x\n", WSAGetLastError());
 #else
-                           errno
+                    EMU_ERR("send_platform_data Error - %x\n", errno);
 #endif
-                           );
                     return true;
                 }
             } else {
@@ -170,18 +158,16 @@ bool platform_server(const SOCKET socket)
             break;
 
         default:
-            printf("Unrecognized platform interface command %x\n",
-                   m_command);
+            EMU_ERR("Unrecognized platform interface command %x\n",
+                    m_command);
             result = send_platform_data(
                 socket, SOCKET_SPDM_COMMAND_UNKOWN, NULL, 0);
             if (!result) {
-                printf("send_platform_data Error - %x\n",
 #ifdef _MSC_VER
-                       WSAGetLastError()
+                EMU_ERR("send_platform_data Error - %x\n", WSAGetLastError());
 #else
-                       errno
+                EMU_ERR("send_platform_data Error - %x\n", errno);
 #endif
-                       );
                 return true;
             }
             return true;
@@ -208,7 +194,7 @@ bool platform_server_routine(uint16_t port_number)
     else {
         result = create_socket(port_number, &responder_socket);
         if (!result) {
-            printf("Create platform service socket fail\n");
+            EMU_ERR("Create platform service socket fail\n");
 #ifdef _MSC_VER
             WSACleanup();
 #endif
@@ -219,7 +205,7 @@ bool platform_server_routine(uint16_t port_number)
     do {
         if (!(m_use_transport_layer == SOCKET_TRANSPORT_TYPE_TCP &&
               m_use_tcp_role_inquiry == SOCKET_TCP_ROLE_INQUIRY)) {
-            printf("Platform server listening on port %d\n", port_number);
+            EMU_LOG("Platform server listening on port %d\n", port_number);
 
             length = sizeof(peer_address);
             m_server_socket =
@@ -227,13 +213,11 @@ bool platform_server_routine(uint16_t port_number)
                        (socklen_t *)&length);
             if (m_server_socket == INVALID_SOCKET) {
                 closesocket(responder_socket);
-                printf("Accept error.  Error is 0x%x\n",
 #ifdef _MSC_VER
-                       WSAGetLastError()
+                EMU_ERR("Accept error.  Error is 0x%x\n", WSAGetLastError());
 #else
-                       errno
+                EMU_ERR("Accept error.  Error is 0x%x\n", errno);
 #endif
-                       );
 #ifdef _MSC_VER
                 WSACleanup();
 #endif
@@ -257,10 +241,10 @@ int main(int argc, char *argv[])
     libspdm_return_t status;
     bool result;
 
-    printf("%s version 0.1\n", "spdm_responder_emu");
     srand((unsigned int)time(NULL));
 
     process_args("spdm_responder_emu", argc, argv);
+    EMU_LOG("%s version 0.1\n", "spdm_responder_emu");
 
     m_spdm_context = spdm_server_init();
     if (m_spdm_context == NULL) {
@@ -270,7 +254,7 @@ int main(int argc, char *argv[])
     if (m_use_transport_layer == SOCKET_TRANSPORT_TYPE_PCI_DOE) {
         status = pci_doe_init_responder ();
         if (LIBSPDM_STATUS_IS_ERROR(status)) {
-            printf("pci_doe_init_responder - %x\n", (uint32_t)status);
+            EMU_ERR("pci_doe_init_responder - %x\n", (uint32_t)status);
             return 1;
         }
     }
@@ -296,7 +280,7 @@ int main(int argc, char *argv[])
         free(m_scratch_buffer);
     }
 
-    printf("Server stopped\n");
+    EMU_INFO("SPDM Responder server stopped\n");
 
     close_pcap_packet_file();
     return (!result);

--- a/spdm_emu/spdm_responder_emu/spdm_responder_spdm.c
+++ b/spdm_emu/spdm_responder_emu/spdm_responder_spdm.c
@@ -69,13 +69,11 @@ libspdm_return_t spdm_device_send_message(void *spdm_context,
     result = send_platform_data(m_server_socket, SOCKET_SPDM_COMMAND_NORMAL,
                                 response, (uint32_t)response_size);
     if (!result) {
-        printf("send_platform_data Error - %x\n",
 #ifdef _MSC_VER
-               WSAGetLastError()
+        EMU_ERR("send_platform_data Error - %x\n", WSAGetLastError());
 #else
-               errno
+        EMU_ERR("send_platform_data Error - %x\n", errno);
 #endif
-               );
         return LIBSPDM_STATUS_SEND_FAIL;
     }
     return LIBSPDM_STATUS_SUCCESS;
@@ -94,13 +92,11 @@ libspdm_return_t spdm_device_receive_message(void *spdm_context,
         receive_platform_data(m_server_socket, &m_command,
                               m_send_receive_buffer, &m_send_receive_buffer_size);
     if (!result) {
-        printf("receive_platform_data Error - %x\n",
 #ifdef _MSC_VER
-               WSAGetLastError()
+        EMU_ERR("receive_platform_data Error - %x\n", WSAGetLastError());
 #else
-               errno
+        EMU_ERR("receive_platform_data Error - %x\n", errno);
 #endif
-               );
         return LIBSPDM_STATUS_RECEIVE_FAIL;
     }
     if (m_command == SOCKET_SPDM_COMMAND_NORMAL) {
@@ -137,7 +133,7 @@ void *spdm_server_init(void)
     void *requester_cert_chain_buffer;
     uint32_t max_spdm_msg_size;
 
-    printf("context_size - 0x%x\n", (uint32_t)libspdm_get_context_size());
+    EMU_LOG("context_size - 0x%x\n", (uint32_t)libspdm_get_context_size());
 
     m_spdm_context = (void *)malloc(libspdm_get_context_size());
     if (m_spdm_context == NULL) {
@@ -476,8 +472,8 @@ void spdm_server_connection_state_callback(
             requester_pub_key_needed = false;
         }
 
-        printf("slot_id - %x\n", m_use_slot_id);
-        printf("req_slot_id - %x\n", m_use_req_slot_id);
+        EMU_LOG("slot_id - %x\n", m_use_slot_id);
+        EMU_LOG("req_slot_id - %x\n", m_use_req_slot_id);
 
         if (m_use_slot_id == 0xFF) {
             if (m_use_asym_algo != 0) {
@@ -751,7 +747,7 @@ void spdm_server_session_state_callback(void *spdm_context,
             libspdm_get_data(spdm_context,
                              LIBSPDM_DATA_SESSION_POLICY,
                              &parameter, &data8, &data_size);
-            printf("session policy - %x\n", data8);
+            EMU_LOG("session policy - %x\n", data8);
         }
         break;
 
@@ -773,14 +769,14 @@ libspdm_return_t spdm_get_endpoint_info_callback (
     uint32_t endpoint_info_size,
     const void *endpoint_info)
 {
-    printf("spdm_get_endpoint_info_callback\n");
-    printf("  subcode - 0x%x\n", subcode);
-    printf("  param2 - 0x%x\n", param2);
-    printf("  request_attributes - 0x%x\n", request_attributes);
-    printf("  endpoint_info_size - 0x%x\n", endpoint_info_size);
-    printf("  endpoint_info:");
+    EMU_LOG("spdm_get_endpoint_info_callback\n");
+    EMU_LOG("  subcode - 0x%x\n", subcode);
+    EMU_LOG("  param2 - 0x%x\n", param2);
+    EMU_LOG("  request_attributes - 0x%x\n", request_attributes);
+    EMU_LOG("  endpoint_info_size - 0x%x\n", endpoint_info_size);
+    EMU_LOG("  endpoint_info:");
     dump_data(endpoint_info, endpoint_info_size);
-    printf("\n");
+    EMU_LOG("\n");
 
     return LIBSPDM_STATUS_SUCCESS;
 }

--- a/spdm_emu/spdm_responder_emu/spdm_responder_tcp.c
+++ b/spdm_emu/spdm_responder_emu/spdm_responder_tcp.c
@@ -29,17 +29,17 @@ bool InitConnectionAndRoleInquiry(SOCKET *sock, uint16_t port_number) {
 
     if (status != LIBSPDM_STATUS_SUCCESS) {
         closesocket(responder_socket);
-        printf("Failed to encode Role-Inquiry message. Status: 0x%x\n", status);
+        EMU_ERR("Failed to encode Role-Inquiry message. Status: 0x%x\n", status);
         return false;
     }
 
     /* Send role_inquiry request */
-    printf("Press ENTER to send Role-Inquiry request...\n");
+    EMU_INFO("Press ENTER to send Role-Inquiry request...\n");
     getchar();
     result = write_bytes(responder_socket, role_inquiry_buf, (uint32_t)role_inquiry_size);
     if (!result) {
         closesocket(responder_socket);
-        printf("Error sending Role-Inquiry request.\n");
+        EMU_ERR("Error sending Role-Inquiry request.\n");
 #ifdef _MSC_VER
         WSACleanup();
 #endif


### PR DESCRIPTION
Introduce EMU_LOG, EMU_ERR & EMU_INFO logging macros gated by a new m_verbose flag. By default only errors and essential messages are shown; passing -v or --verbose restores full platform traces and hex dumps. All printf() calls in spdm_requester_emu & spdm_responder_emu are converted to the appropriate macro.

Feature #478 