### PR TITLE
Added support for building with external libspdm

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ option(ENABLE_SYSTEMD "Install systemd service file" OFF)
 set(DEVICE ${DEVICE} CACHE STRING "Choose the test device: sample tpm, and default is sample" FORCE)
 
 option(LIBSPDM_TPM_SUPPORT "Add TPM support in crypt_ext" OFF)
+option(USE_SYSTEM_LIBSPDM "Use system provided libspdm" OFF)
 
 if(NOT GCOV)
     set(GCOV "OFF")
@@ -29,9 +30,23 @@ if (NOT DEVICE)
 endif()
 
 set(SPDM_EMU_DIR ${PROJECT_SOURCE_DIR})
-set(LIBSPDM_DIR ${PROJECT_SOURCE_DIR}/libspdm)
 set(SPDM_RESPONDER_VALIDATOR_DIR ${PROJECT_SOURCE_DIR}/SPDM-Responder-Validator)
 set(COMMON_TEST_FRAMEWORK_DIR ${PROJECT_SOURCE_DIR}/SPDM-Responder-Validator/common_test_framework)
+
+if (USE_SYSTEM_LIBSPDM)
+  find_package(PkgConfig REQUIRED)
+  pkg_check_modules(LIBSPDM REQUIRED libspdm)
+  pkg_get_variable(_LIBSPDM_INCLUDE_PATH libspdm includedir)
+  include_directories(
+    "${_LIBSPDM_INCLUDE_PATH}/include"
+  )
+else (USE_SYSTEM_LIBSPDM)
+  set(LIBSPDM_DIR "${PROJECT_SOURCE_DIR}/libspdm")
+  include_directories(
+    "${LIBSPDM_DIR}/include"
+    "${LIBSPDM_DIR}/os_stub/include"
+  )
+endif (USE_SYSTEM_LIBSPDM)
 
 #
 # OpenSSL specific compiled libraries.
@@ -632,19 +647,20 @@ elseif(CMAKE_SYSTEM_NAME MATCHES "Windows")
                        COMMAND xcopy /y /s ${SRC} ${DEST})
 endif()
 
-if(CRYPTO STREQUAL "mbedtls")
-    add_subdirectory(${LIBSPDM_DIR}/os_stub/cryptlib_mbedtls out/cryptlib_mbedtls.out)
-elseif(CRYPTO STREQUAL "openssl")
-    add_subdirectory(${LIBSPDM_DIR}/os_stub/cryptlib_openssl out/cryptlib_openssl.out)
-endif()
+if (NOT USE_SYSTEM_LIBSPDM)
+  if(CRYPTO STREQUAL "mbedtls")
+      add_subdirectory(${LIBSPDM_DIR}/os_stub/cryptlib_mbedtls out/cryptlib_mbedtls.out)
+  elseif(CRYPTO STREQUAL "openssl")
+      add_subdirectory(${LIBSPDM_DIR}/os_stub/cryptlib_openssl out/cryptlib_openssl.out)
+  endif()
 
-if(NOT ENABLE_BINARY_BUILD STREQUAL "1")
-    if(CRYPTO STREQUAL "mbedtls")
-        add_subdirectory(${LIBSPDM_DIR}/os_stub/mbedtlslib out/mbedtlslib.out)
-    elseif(CRYPTO STREQUAL "openssl")
-        add_subdirectory(${LIBSPDM_DIR}/os_stub/openssllib out/openssllib.out)
-    endif()
-endif()
+  if(NOT ENABLE_BINARY_BUILD STREQUAL "1")
+      if(CRYPTO STREQUAL "mbedtls")
+          add_subdirectory(${LIBSPDM_DIR}/os_stub/mbedtlslib out/mbedtlslib.out)
+      elseif(CRYPTO STREQUAL "openssl")
+          add_subdirectory(${LIBSPDM_DIR}/os_stub/openssllib out/openssllib.out)
+      endif()
+  endif()
 
     add_subdirectory(${LIBSPDM_DIR}/library/spdm_common_lib out/spdm_common_lib.out)
     add_subdirectory(${LIBSPDM_DIR}/library/spdm_requester_lib out/spdm_requester_lib.out)
@@ -662,6 +678,7 @@ endif()
     add_subdirectory(${LIBSPDM_DIR}/os_stub/spdm_device_secret_lib_${DEVICE} out/spdm_device_secret_lib_${DEVICE}.out)
     add_subdirectory(${LIBSPDM_DIR}/os_stub/platform_lib out/platform_lib.out)
     add_subdirectory(${LIBSPDM_DIR}/os_stub/spdm_crypt_ext_lib out/spdm_crypt_ext_lib.out)
+endif (NOT USE_SYSTEM_LIBSPDM)
 
     add_subdirectory(library/spdm_transport_none_lib)
     add_subdirectory(library/mctp_requester_lib)

--- a/spdm-device-sample/spdm_device_sample/CMakeLists.txt
+++ b/spdm-device-sample/spdm_device_sample/CMakeLists.txt
@@ -772,6 +772,11 @@ endif()
 add_compile_options(-DLIBSPDM_CONFIG="${PROJECT_SOURCE_DIR}/include/spdm_lib_config.h")
 add_compile_options(-UMBEDTLS_CONFIG_FILE -DMBEDTLS_CONFIG_FILE="${PROJECT_SOURCE_DIR}/include/mbedtls/config.h")
 
+include_directories(
+  ${LIBSPDM_DIR}/include
+  ${LIBSPDM_DIR}/os_stub/include
+)
+
     if(CRYPTO STREQUAL "mbedtls")
         add_subdirectory(${LIBSPDM_DIR}/os_stub/cryptlib_mbedtls out/cryptlib_mbedtls.lib)
     elseif(CRYPTO STREQUAL "openssl")

--- a/spdm-device-sample/spdm_device_sample/library/spdm_device_secret_lib/spdm_device_secret_lib_internal.h
+++ b/spdm-device-sample/spdm_device_sample/library/spdm_device_secret_lib/spdm_device_secret_lib_internal.h
@@ -14,8 +14,8 @@
 
 #include "hal/library/cryptlib.h"
 #include "library/spdm_crypt_lib.h"
-#include "spdm_crypt_ext_lib/spdm_crypt_ext_lib.h"
-#include "spdm_crypt_ext_lib/cryptlib_ext.h"
+#include "library/spdm_crypt_ext_lib.h"
+#include "hal/library/cryptlib_ext.h"
 #include "hal/library/responder/asymsignlib.h"
 #include "hal/library/responder/csrlib.h"
 #include "hal/library/responder/measlib.h"

--- a/spdm_emu/spdm_device_attester_sample/CMakeLists.txt
+++ b/spdm_emu/spdm_device_attester_sample/CMakeLists.txt
@@ -22,52 +22,63 @@ set(src_spdm_device_attester_sample
     ${PROJECT_SOURCE_DIR}/spdm_emu/spdm_emu_common/support.c
 )
 
-set(spdm_device_attester_sample_LIBRARY
-    memlib
-    debuglib_null
-    spdm_requester_lib
-    spdm_common_lib
-    ${CRYPTO_LIB_PATHS}
-    rnglib
-    cryptlib_${CRYPTO}
-    malloclib
-    spdm_crypt_lib
-    spdm_crypt_ext_lib
-    spdm_secured_message_lib
-    spdm_transport_mctp_lib
-    spdm_transport_pcidoe_lib
+if (USE_SYSTEM_LIBSPDM)
+  add_executable(spdm_device_attester_sample ${src_spdm_device_attester_sample})
+  target_link_libraries(spdm_device_attester_sample PRIVATE
     spdm_transport_none_lib
-    spdm_transport_tcp_lib
-    spdm_device_secret_lib_${DEVICE}
-    mctp_requester_lib
     pci_doe_requester_lib
-    platform_lib
     spdm_responder_conformance_test_lib
     common_test_utility_lib
-)
+    ${LIBSPDM_LIBRARIES}
+  )
+else (USE_SYSTEM_LIBSPDM)
+  set(spdm_device_attester_sample_LIBRARY
+      memlib
+      debuglib_null
+      spdm_requester_lib
+      spdm_common_lib
+      ${CRYPTO_LIB_PATHS}
+      rnglib
+      cryptlib_${CRYPTO}
+      malloclib
+      spdm_crypt_lib
+      spdm_crypt_ext_lib
+      spdm_secured_message_lib
+      spdm_transport_mctp_lib
+      spdm_transport_pcidoe_lib
+      spdm_transport_none_lib
+      spdm_transport_tcp_lib
+      spdm_device_secret_lib_${DEVICE}
+      mctp_requester_lib
+      pci_doe_requester_lib
+      platform_lib
+      spdm_responder_conformance_test_lib
+      common_test_utility_lib
+  )
 
-if((TOOLCHAIN STREQUAL "KLEE") OR (TOOLCHAIN STREQUAL "CBMC"))
-    add_executable(spdm_device_attester_sample
-                   ${src_spdm_responder_test_client}
-                   $<TARGET_OBJECTS:memlib>
-                   $<TARGET_OBJECTS:debuglib_null>
-                   $<TARGET_OBJECTS:spdm_requester_lib>
-                   $<TARGET_OBJECTS:spdm_common_lib>
-                   $<TARGET_OBJECTS:${CRYPTO_LIB_PATHS}>
-                   $<TARGET_OBJECTS:rnglib>
-                   $<TARGET_OBJECTS:cryptlib_${CRYPTO}>
-                   $<TARGET_OBJECTS:malloclib>
-                   $<TARGET_OBJECTS:spdm_crypt_lib>
-                   $<TARGET_OBJECTS:spdm_secured_message_lib>
-                   $<TARGET_OBJECTS:spdm_transport_mctp_lib>
-                   $<TARGET_OBJECTS:spdm_transport_pcidoe_lib>
-                   $<TARGET_OBJECTS:spdm_transport_tcp_lib>
-                   $<TARGET_OBJECTS:spdm_device_secret_lib_${DEVICE}>
-                   $<TARGET_OBJECTS:platform_lib>
-                   $<TARGET_OBJECTS:spdm_responder_conformance_test_lib>
-                   $<TARGET_OBJECTS:common_test_utility_lib>
-    )
-else()
-    add_executable(spdm_device_attester_sample ${src_spdm_device_attester_sample})
-    target_link_libraries(spdm_device_attester_sample ${spdm_device_attester_sample_LIBRARY})
-endif()
+  if((TOOLCHAIN STREQUAL "KLEE") OR (TOOLCHAIN STREQUAL "CBMC"))
+      add_executable(spdm_device_attester_sample
+                    ${src_spdm_responder_test_client}
+                    $<TARGET_OBJECTS:memlib>
+                    $<TARGET_OBJECTS:debuglib_null>
+                    $<TARGET_OBJECTS:spdm_requester_lib>
+                    $<TARGET_OBJECTS:spdm_common_lib>
+                    $<TARGET_OBJECTS:${CRYPTO_LIB_PATHS}>
+                    $<TARGET_OBJECTS:rnglib>
+                    $<TARGET_OBJECTS:cryptlib_${CRYPTO}>
+                    $<TARGET_OBJECTS:malloclib>
+                    $<TARGET_OBJECTS:spdm_crypt_lib>
+                    $<TARGET_OBJECTS:spdm_secured_message_lib>
+                    $<TARGET_OBJECTS:spdm_transport_mctp_lib>
+                    $<TARGET_OBJECTS:spdm_transport_pcidoe_lib>
+                    $<TARGET_OBJECTS:spdm_transport_tcp_lib>
+                    $<TARGET_OBJECTS:spdm_device_secret_lib_${DEVICE}>
+                    $<TARGET_OBJECTS:platform_lib>
+                    $<TARGET_OBJECTS:spdm_responder_conformance_test_lib>
+                    $<TARGET_OBJECTS:common_test_utility_lib>
+      )
+  else()
+      add_executable(spdm_device_attester_sample ${src_spdm_device_attester_sample})
+      target_link_libraries(spdm_device_attester_sample ${spdm_device_attester_sample_LIBRARY})
+  endif()
+endif (USE_SYSTEM_LIBSPDM)

--- a/spdm_emu/spdm_device_validator_sample/CMakeLists.txt
+++ b/spdm_emu/spdm_device_validator_sample/CMakeLists.txt
@@ -24,51 +24,64 @@ set(src_spdm_device_validator_sample
     ${PROJECT_SOURCE_DIR}/spdm_emu/spdm_emu_common/support.c
 )
 
-set(spdm_device_validator_sample_LIBRARY
-    memlib
-    debuglib_null
-    spdm_requester_lib
-    spdm_common_lib
-    ${CRYPTO_LIB_PATHS}
-    rnglib
-    cryptlib_${CRYPTO}
-    malloclib
-    spdm_crypt_lib
-    spdm_crypt_ext_lib
-    spdm_secured_message_lib
-    spdm_transport_mctp_lib
-    spdm_transport_pcidoe_lib
-    spdm_transport_none_lib
-    spdm_transport_tcp_lib
-    spdm_device_secret_lib_${DEVICE}
-    mctp_requester_lib
-    pci_doe_requester_lib
-    platform_lib
-    spdm_responder_conformance_test_lib
-    common_test_utility_lib
+if (USE_SYSTEM_LIBSPDM)
+add_executable(spdm_device_validator_sample ${src_spdm_device_validator_sample})
+target_link_libraries(spdm_device_validator_sample PRIVATE
+  mctp_requester_lib
+  pci_doe_requester_lib
+  spdm_responder_conformance_test_lib
+  common_test_utility_lib
+  spdm_transport_none_lib
+  ${LIBSPDM_LIBRARIES}
 )
+else (USE_SYSTEM_LIBSPDM)
+  set(spdm_device_validator_sample_LIBRARY
+      memlib
+      debuglib_null
+      spdm_requester_lib
+      spdm_common_lib
+      ${CRYPTO_LIB_PATHS}
+      rnglib
+      cryptlib_${CRYPTO}
+      malloclib
+      spdm_crypt_lib
+      spdm_crypt_ext_lib
+      spdm_secured_message_lib
+      spdm_transport_mctp_lib
+      spdm_transport_pcidoe_lib
+      spdm_transport_none_lib
+      spdm_transport_tcp_lib
+      spdm_device_secret_lib_${DEVICE}
+      mctp_requester_lib
+      pci_doe_requester_lib
+      platform_lib
+      spdm_responder_conformance_test_lib
+      common_test_utility_lib
+  )
 
-if((TOOLCHAIN STREQUAL "KLEE") OR (TOOLCHAIN STREQUAL "CBMC"))
-    add_executable(spdm_device_validator_sample
-                   ${src_spdm_responder_test_client}
-                   $<TARGET_OBJECTS:memlib>
-                   $<TARGET_OBJECTS:debuglib_null>
-                   $<TARGET_OBJECTS:spdm_requester_lib>
-                   $<TARGET_OBJECTS:spdm_common_lib>
-                   $<TARGET_OBJECTS:${CRYPTO_LIB_PATHS}>
-                   $<TARGET_OBJECTS:rnglib>
-                   $<TARGET_OBJECTS:cryptlib_${CRYPTO}>
-                   $<TARGET_OBJECTS:malloclib>
-                   $<TARGET_OBJECTS:spdm_crypt_lib>
-                   $<TARGET_OBJECTS:spdm_secured_message_lib>
-                   $<TARGET_OBJECTS:spdm_transport_mctp_lib>
-                   $<TARGET_OBJECTS:spdm_transport_pcidoe_lib>
-                   $<TARGET_OBJECTS:spdm_device_secret_lib_${DEVICE}>
-                   $<TARGET_OBJECTS:platform_lib>
-                   $<TARGET_OBJECTS:spdm_responder_conformance_test_lib>
-                   $<TARGET_OBJECTS:common_test_utility_lib>
-    )
-else()
-    add_executable(spdm_device_validator_sample ${src_spdm_device_validator_sample})
-    target_link_libraries(spdm_device_validator_sample ${spdm_device_validator_sample_LIBRARY})
-endif()
+  if((TOOLCHAIN STREQUAL "KLEE") OR (TOOLCHAIN STREQUAL "CBMC"))
+      add_executable(spdm_device_validator_sample
+                    ${src_spdm_responder_test_client}
+                    $<TARGET_OBJECTS:memlib>
+                    $<TARGET_OBJECTS:debuglib_null>
+                    $<TARGET_OBJECTS:spdm_requester_lib>
+                    $<TARGET_OBJECTS:spdm_common_lib>
+                    $<TARGET_OBJECTS:${CRYPTO_LIB_PATHS}>
+                    $<TARGET_OBJECTS:rnglib>
+                    $<TARGET_OBJECTS:cryptlib_${CRYPTO}>
+                    $<TARGET_OBJECTS:malloclib>
+                    $<TARGET_OBJECTS:spdm_crypt_lib>
+                    $<TARGET_OBJECTS:spdm_secured_message_lib>
+                    $<TARGET_OBJECTS:spdm_transport_mctp_lib>
+                    $<TARGET_OBJECTS:spdm_transport_pcidoe_lib>
+                    $<TARGET_OBJECTS:spdm_device_secret_lib_${DEVICE}>
+                    $<TARGET_OBJECTS:platform_lib>
+                    $<TARGET_OBJECTS:spdm_responder_conformance_test_lib>
+                    $<TARGET_OBJECTS:common_test_utility_lib>
+      )
+  else()
+      add_executable(spdm_device_validator_sample ${src_spdm_device_validator_sample})
+      target_link_libraries(spdm_device_validator_sample ${spdm_device_validator_sample_LIBRARY})
+  endif()
+
+endif (USE_SYSTEM_LIBSPDM)

--- a/spdm_emu/spdm_emu_common/spdm_emu.h
+++ b/spdm_emu/spdm_emu_common/spdm_emu.h
@@ -10,7 +10,7 @@
 #include "hal/base.h"
 #include "hal/library/memlib.h"
 #include "library/spdm_common_lib.h"
-#include "spdm_device_secret_lib_internal.h"
+#include "internal/libspdm_device_secret_lib.h"
 
 #include "os_include.h"
 #include "stdio.h"

--- a/spdm_emu/spdm_requester_emu/CMakeLists.txt
+++ b/spdm_emu/spdm_requester_emu/CMakeLists.txt
@@ -28,73 +28,88 @@ set(src_spdm_requester_emu
     ${PROJECT_SOURCE_DIR}/spdm_emu/spdm_emu_common/support.c
 )
 
-set(spdm_requester_emu_LIBRARY
-    memlib
-    ${SPDM_DEBUG_LIB_NAME}
-    spdm_requester_lib
-    spdm_common_lib
-    ${CRYPTO_LIB_PATHS}
-    rnglib
-    cryptlib_${CRYPTO}
-    malloclib
-    spdm_crypt_lib
-    spdm_crypt_ext_lib
-    spdm_secured_message_lib
-    spdm_transport_mctp_lib
-    spdm_transport_pcidoe_lib
-    spdm_transport_tcp_lib
-    spdm_transport_none_lib
-    spdm_device_secret_lib_${DEVICE}
+if (USE_SYSTEM_LIBSPDM)
+  message("LIBSPDM_LIBRARIES: ${LIBSPDM_LIBRARIES}")
+  add_executable(spdm_requester_emu ${src_spdm_requester_emu})
+  target_link_libraries(spdm_requester_emu PRIVATE
     mctp_requester_lib
     pci_doe_requester_lib
     pci_ide_km_requester_lib
     pci_tdisp_requester_lib
     cxl_ide_km_requester_lib
     cxl_tsp_requester_lib
-    platform_lib
-)
+    spdm_transport_none_lib
+    ${LIBSPDM_LIBRARIES}
+  )
+else (USE_SYSTEM_LIBSPDM)
+  set(spdm_requester_emu_LIBRARY
+      memlib
+      ${SPDM_DEBUG_LIB_NAME}
+      spdm_requester_lib
+      spdm_common_lib
+      ${CRYPTO_LIB_PATHS}
+      rnglib
+      cryptlib_${CRYPTO}
+      malloclib
+      spdm_crypt_lib
+      spdm_crypt_ext_lib
+      spdm_secured_message_lib
+      spdm_transport_mctp_lib
+      spdm_transport_pcidoe_lib
+      spdm_transport_tcp_lib
+      spdm_transport_none_lib
+      spdm_device_secret_lib_${DEVICE}
+      mctp_requester_lib
+      pci_doe_requester_lib
+      pci_ide_km_requester_lib
+      pci_tdisp_requester_lib
+      cxl_ide_km_requester_lib
+      cxl_tsp_requester_lib
+      platform_lib
+  )
 
-if((TOOLCHAIN STREQUAL "KLEE") OR (TOOLCHAIN STREQUAL "CBMC"))
-    add_executable(spdm_requester_emu
-                   ${src_spdm_requester_emu}
-                   $<TARGET_OBJECTS:memlib>
-                   $<TARGET_OBJECTS:debuglib>
-                   $<TARGET_OBJECTS:spdm_requester_lib>
-                   $<TARGET_OBJECTS:spdm_common_lib>
-                   $<TARGET_OBJECTS:${CRYPTO_LIB_PATHS}>
-                   $<TARGET_OBJECTS:rnglib>
-                   $<TARGET_OBJECTS:cryptlib_${CRYPTO}>
-                   $<TARGET_OBJECTS:malloclib>
-                   $<TARGET_OBJECTS:spdm_crypt_lib>
-                   $<TARGET_OBJECTS:spdm_secured_message_lib>
-                   $<TARGET_OBJECTS:spdm_transport_mctp_lib>
-                   $<TARGET_OBJECTS:spdm_transport_pcidoe_lib>
-                   $<TARGET_OBJECTS:spdm_transport_tcp_lib>
-                   $<TARGET_OBJECTS:spdm_device_secret_lib_${DEVICE}>
-                   $<TARGET_OBJECTS:mctp_requester_lib>
-                   $<TARGET_OBJECTS:pci_doe_requester_lib>
-                   $<TARGET_OBJECTS:pci_ide_km_requester_lib>
-                   $<TARGET_OBJECTS:pci_tdisp_requester_lib>
-                   $<TARGET_OBJECTS:cxl_ide_km_requester_lib>
-                   $<TARGET_OBJECTS:cxl_tsp_requester_lib>
-                   $<TARGET_OBJECTS:platform_lib>
-    )
-else()
-    add_executable(spdm_requester_emu ${src_spdm_requester_emu})
-    target_link_libraries(spdm_requester_emu ${spdm_requester_emu_LIBRARY})
-endif()
+  if((TOOLCHAIN STREQUAL "KLEE") OR (TOOLCHAIN STREQUAL "CBMC"))
+      add_executable(spdm_requester_emu
+                    ${src_spdm_requester_emu}
+                    $<TARGET_OBJECTS:memlib>
+                    $<TARGET_OBJECTS:debuglib>
+                    $<TARGET_OBJECTS:spdm_requester_lib>
+                    $<TARGET_OBJECTS:spdm_common_lib>
+                    $<TARGET_OBJECTS:${CRYPTO_LIB_PATHS}>
+                    $<TARGET_OBJECTS:rnglib>
+                    $<TARGET_OBJECTS:cryptlib_${CRYPTO}>
+                    $<TARGET_OBJECTS:malloclib>
+                    $<TARGET_OBJECTS:spdm_crypt_lib>
+                    $<TARGET_OBJECTS:spdm_secured_message_lib>
+                    $<TARGET_OBJECTS:spdm_transport_mctp_lib>
+                    $<TARGET_OBJECTS:spdm_transport_pcidoe_lib>
+                    $<TARGET_OBJECTS:spdm_transport_tcp_lib>
+                    $<TARGET_OBJECTS:spdm_device_secret_lib_${DEVICE}>
+                    $<TARGET_OBJECTS:mctp_requester_lib>
+                    $<TARGET_OBJECTS:pci_doe_requester_lib>
+                    $<TARGET_OBJECTS:pci_ide_km_requester_lib>
+                    $<TARGET_OBJECTS:pci_tdisp_requester_lib>
+                    $<TARGET_OBJECTS:cxl_ide_km_requester_lib>
+                    $<TARGET_OBJECTS:cxl_tsp_requester_lib>
+                    $<TARGET_OBJECTS:platform_lib>
+      )
+  else()
+      add_executable(spdm_requester_emu ${src_spdm_requester_emu})
+      target_link_libraries(spdm_requester_emu ${spdm_requester_emu_LIBRARY})
+  endif()
 
-# Windows DLL path fix for OpenSSL shared library
-if(CMAKE_SYSTEM_NAME MATCHES "Windows" AND NOT TOOLCHAIN STREQUAL "NONE")
-    if(CRYPTO STREQUAL "openssl")
-        # Copy OpenSSL DLL to emu directory for runtime linking
-        if(TARGET openssllib)
-            add_custom_command(TARGET spdm_requester_emu POST_BUILD
-                COMMAND ${CMAKE_COMMAND} -E copy_if_different
-                $<TARGET_FILE:openssllib>
-                $<TARGET_FILE_DIR:spdm_requester_emu>
-                COMMENT "Copying OpenSSL DLL to emu directory"
-            )
-        endif()
-    endif()
-endif()
+  # Windows DLL path fix for OpenSSL shared library
+  if(CMAKE_SYSTEM_NAME MATCHES "Windows" AND NOT TOOLCHAIN STREQUAL "NONE")
+      if(CRYPTO STREQUAL "openssl")
+          # Copy OpenSSL DLL to emu directory for runtime linking
+          if(TARGET openssllib)
+              add_custom_command(TARGET spdm_requester_emu POST_BUILD
+                  COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                  $<TARGET_FILE:openssllib>
+                  $<TARGET_FILE_DIR:spdm_requester_emu>
+                  COMMENT "Copying OpenSSL DLL to emu directory"
+              )
+          endif()
+      endif()
+  endif()
+endif(USE_SYSTEM_LIBSPDM)

--- a/spdm_emu/spdm_responder_emu/CMakeLists.txt
+++ b/spdm_emu/spdm_responder_emu/CMakeLists.txt
@@ -24,23 +24,10 @@ set(src_spdm_responder_emu
     ${PROJECT_SOURCE_DIR}/spdm_emu/spdm_emu_common/support.c
 )
 
-set(spdm_responder_emu_LIBRARY
-    memlib
-    ${SPDM_DEBUG_LIB_NAME}
-    spdm_responder_lib
-    spdm_common_lib
-    ${CRYPTO_LIB_PATHS}
-    rnglib
-    cryptlib_${CRYPTO}
-    malloclib
-    spdm_crypt_lib
-    spdm_crypt_ext_lib
-    spdm_secured_message_lib
-    spdm_transport_mctp_lib
-    spdm_transport_pcidoe_lib
-    spdm_transport_tcp_lib
-    spdm_transport_none_lib
-    spdm_device_secret_lib_${DEVICE}
+if (USE_SYSTEM_LIBSPDM)
+  message("LIBSPDM_LIBRARIES: ${LIBSPDM_LIBRARIES}")
+  add_executable(spdm_responder_emu ${src_spdm_responder_emu})
+  target_link_libraries(spdm_responder_emu PRIVATE
     mctp_responder_lib
     pci_doe_responder_lib
     pci_ide_km_responder_lib
@@ -51,42 +38,75 @@ set(spdm_responder_emu_LIBRARY
     cxl_ide_km_device_lib_sample
     cxl_tsp_responder_lib
     cxl_tsp_device_lib_sample
-    platform_lib
-)
+    spdm_transport_none_lib
+    ${LIBSPDM_LIBRARIES}
+  )
+else (USE_SYSTEM_LIBSPDM)
+  set(spdm_responder_emu_LIBRARY
+      memlib
+      ${SPDM_DEBUG_LIB_NAME}
+      spdm_responder_lib
+      spdm_common_lib
+      ${CRYPTO_LIB_PATHS}
+      rnglib
+      cryptlib_${CRYPTO}
+      malloclib
+      spdm_crypt_lib
+      spdm_crypt_ext_lib
+      spdm_secured_message_lib
+      spdm_transport_mctp_lib
+      spdm_transport_pcidoe_lib
+      spdm_transport_tcp_lib
+      spdm_transport_none_lib
+      spdm_device_secret_lib_${DEVICE}
+      mctp_responder_lib
+      pci_doe_responder_lib
+      pci_ide_km_responder_lib
+      pci_ide_km_device_lib_sample
+      pci_tdisp_responder_lib
+      pci_tdisp_device_lib_sample
+      cxl_ide_km_responder_lib
+      cxl_ide_km_device_lib_sample
+      cxl_tsp_responder_lib
+      cxl_tsp_device_lib_sample
+      platform_lib
+  )
 
-if((TOOLCHAIN STREQUAL "KLEE") OR (TOOLCHAIN STREQUAL "CBMC"))
-    add_executable(spdm_responder_emu
-                   ${src_spdm_responder_emu}
-                   $<TARGET_OBJECTS:memlib>
-                   $<TARGET_OBJECTS:debuglib>
-                   $<TARGET_OBJECTS:spdm_responder_lib>
-                   $<TARGET_OBJECTS:spdm_common_lib>
-                   $<TARGET_OBJECTS:${CRYPTO_LIB_PATHS}>
-                   $<TARGET_OBJECTS:rnglib>
-                   $<TARGET_OBJECTS:cryptlib_${CRYPTO}>
-                   $<TARGET_OBJECTS:malloclib>
-                   $<TARGET_OBJECTS:spdm_crypt_lib>
-                   $<TARGET_OBJECTS:spdm_secured_message_lib>
-                   $<TARGET_OBJECTS:spdm_transport_mctp_lib>
-                   $<TARGET_OBJECTS:spdm_transport_pcidoe_lib>
-                   $<TARGET_OBJECTS:spdm_transport_tcp_lib>
-                   $<TARGET_OBJECTS:spdm_device_secret_lib_${DEVICE}>
-                   $<TARGET_OBJECTS:mctp_responder_lib>
-                   $<TARGET_OBJECTS:pci_doe_responder_lib>
-                   $<TARGET_OBJECTS:pci_ide_km_responder_lib>
-                   $<TARGET_OBJECTS:pci_ide_km_device_lib_sample>
-                   $<TARGET_OBJECTS:pci_tdisp_responder_lib>
-                   $<TARGET_OBJECTS:pci_tdisp_device_lib_sample>
-                   $<TARGET_OBJECTS:cxl_ide_km_responder_lib>
-                   $<TARGET_OBJECTS:cxl_ide_km_device_lib_sample>
-                   $<TARGET_OBJECTS:cxl_tsp_responder_lib>
-                   $<TARGET_OBJECTS:cxl_tsp_device_lib_sample>
-                   $<TARGET_OBJECTS:platform_lib>
-    )
-else()
-    add_executable(spdm_responder_emu ${src_spdm_responder_emu})
-    target_link_libraries(spdm_responder_emu ${spdm_responder_emu_LIBRARY})
+  if((TOOLCHAIN STREQUAL "KLEE") OR (TOOLCHAIN STREQUAL "CBMC"))
+      add_executable(spdm_responder_emu
+                    ${src_spdm_responder_emu}
+                    $<TARGET_OBJECTS:memlib>
+                    $<TARGET_OBJECTS:debuglib>
+                    $<TARGET_OBJECTS:spdm_responder_lib>
+                    $<TARGET_OBJECTS:spdm_common_lib>
+                    $<TARGET_OBJECTS:${CRYPTO_LIB_PATHS}>
+                    $<TARGET_OBJECTS:rnglib>
+                    $<TARGET_OBJECTS:cryptlib_${CRYPTO}>
+                    $<TARGET_OBJECTS:malloclib>
+                    $<TARGET_OBJECTS:spdm_crypt_lib>
+                    $<TARGET_OBJECTS:spdm_secured_message_lib>
+                    $<TARGET_OBJECTS:spdm_transport_mctp_lib>
+                    $<TARGET_OBJECTS:spdm_transport_pcidoe_lib>
+                    $<TARGET_OBJECTS:spdm_transport_tcp_lib>
+                    $<TARGET_OBJECTS:spdm_device_secret_lib_${DEVICE}>
+                    $<TARGET_OBJECTS:mctp_responder_lib>
+                    $<TARGET_OBJECTS:pci_doe_responder_lib>
+                    $<TARGET_OBJECTS:pci_ide_km_responder_lib>
+                    $<TARGET_OBJECTS:pci_ide_km_device_lib_sample>
+                    $<TARGET_OBJECTS:pci_tdisp_responder_lib>
+                    $<TARGET_OBJECTS:pci_tdisp_device_lib_sample>
+                    $<TARGET_OBJECTS:cxl_ide_km_responder_lib>
+                    $<TARGET_OBJECTS:cxl_ide_km_device_lib_sample>
+                    $<TARGET_OBJECTS:cxl_tsp_responder_lib>
+                    $<TARGET_OBJECTS:cxl_tsp_device_lib_sample>
+                    $<TARGET_OBJECTS:platform_lib>
+      )
+  else()
+      add_executable(spdm_responder_emu ${src_spdm_responder_emu})
+      target_link_libraries(spdm_responder_emu ${spdm_responder_emu_LIBRARY})
+  endif()
 endif()
+
 
 # Windows DLL path fix for OpenSSL shared library
 if(CMAKE_SYSTEM_NAME MATCHES "Windows" AND NOT TOOLCHAIN STREQUAL "NONE")


### PR DESCRIPTION
This PR refactors the spdm-emu build system to decouple it from the libspdm source tree and enable builds against an externally provided libspdm.