### PR TITLE
spdm_requester_emu: add SUPPORTED_ALGO probe for SupportedAlgorithms

### DIFF
--- a/.github/workflows/chunk_check.yml
+++ b/.github/workflows/chunk_check.yml
@@ -47,6 +47,18 @@ jobs:
           ./spdm_requester_emu >requester.log
           sleep 10s
 
+      - name: Enable_chunk_SupportedAlgorithms_PCIDOE(transfer size consistent)
+        run: |
+          cd build/bin
+          # DataTransferSize is 42 (RECEIVER_BUFFER_SIZE 170 - transport 128), so the
+          # SupportedAlgorithms-bearing CAPABILITIES response is transferred via chunking.
+          # Run the full connection (SUPPORTED_ALGO plus the default connection steps) and the
+          # default session flow so the whole transcript runs on top of the chunked CAPABILITIES.
+          ./spdm_responder_emu --trans PCI_DOE &
+          sleep 5s
+          ./spdm_requester_emu --trans PCI_DOE --exe_conn SUPPORTED_ALGO,DIGEST,CERT,CHAL,MEAS,MEL,GET_CSR,SET_CERT,GET_KEY_PAIR_INFO,SET_KEY_PAIR_INFO,EP_INFO >requester.log
+          sleep 10s
+
       - name: Build1
         run: |
           mkdir build1
@@ -99,6 +111,18 @@ jobs:
           ./spdm_responder_emu --trans PCI_DOE &
           sleep 5s
           ./spdm_requester_emu --trans PCI_DOE >requester.log
+          sleep 10s
+
+      - name: Enable_chunk_SupportedAlgorithms_PCIDOE(transfer size consistent)
+        run: |
+          cd build/bin
+          # DataTransferSize is 42 (RECEIVER_BUFFER_SIZE 170 - transport 128), so the
+          # SupportedAlgorithms-bearing CAPABILITIES response is transferred via chunking.
+          # Run the full connection (SUPPORTED_ALGO plus the default connection steps) and the
+          # default session flow so the whole transcript runs on top of the chunked CAPABILITIES.
+          ./spdm_responder_emu --trans PCI_DOE &
+          sleep 5s
+          ./spdm_requester_emu --trans PCI_DOE --exe_conn SUPPORTED_ALGO,DIGEST,CERT,CHAL,MEAS,MEL,GET_CSR,SET_CERT,GET_KEY_PAIR_INFO,SET_KEY_PAIR_INFO,EP_INFO >requester.log
           sleep 10s
 
       - name: Build1
@@ -156,6 +180,16 @@ jobs:
           ./spdm_responder_emu --trans PCI_DOE &
           sleep 5s
           ./spdm_requester_emu --trans PCI_DOE
+      - name: Enable_chunk_SupportedAlgorithms_PCIDOE(transfer size consistent)
+        run: |
+          cd build/bin
+          # DataTransferSize is 42 (RECEIVER_BUFFER_SIZE 170 - transport 128), so the
+          # SupportedAlgorithms-bearing CAPABILITIES response is transferred via chunking.
+          # Run the full connection (SUPPORTED_ALGO plus the default connection steps) and the
+          # default session flow so the whole transcript runs on top of the chunked CAPABILITIES.
+          ./spdm_responder_emu --trans PCI_DOE &
+          sleep 5s
+          ./spdm_requester_emu --trans PCI_DOE --exe_conn SUPPORTED_ALGO,DIGEST,CERT,CHAL,MEAS,MEL,GET_CSR,SET_CERT,GET_KEY_PAIR_INFO,SET_KEY_PAIR_INFO,EP_INFO
 
   VS2019_openssl_build:
     runs-on: windows-latest
@@ -191,3 +225,13 @@ jobs:
           ./spdm_responder_emu --trans PCI_DOE &
           sleep 5s
           ./spdm_requester_emu --trans PCI_DOE
+      - name: Enable_chunk_SupportedAlgorithms_PCIDOE(transfer size consistent)
+        run: |
+          cd build/bin
+          # DataTransferSize is 42 (RECEIVER_BUFFER_SIZE 170 - transport 128), so the
+          # SupportedAlgorithms-bearing CAPABILITIES response is transferred via chunking.
+          # Run the full connection (SUPPORTED_ALGO plus the default connection steps) and the
+          # default session flow so the whole transcript runs on top of the chunked CAPABILITIES.
+          ./spdm_responder_emu --trans PCI_DOE &
+          sleep 5s
+          ./spdm_requester_emu --trans PCI_DOE --exe_conn SUPPORTED_ALGO,DIGEST,CERT,CHAL,MEAS,MEL,GET_CSR,SET_CERT,GET_KEY_PAIR_INFO,SET_KEY_PAIR_INFO,EP_INFO

--- a/doc/spdm_emu.md
+++ b/doc/spdm_emu.md
@@ -39,7 +39,7 @@ This document describes spdm_requester_emu and spdm_responder_emu tool. It can b
          [--save_state <NegotiateStateFileName>]
          [--load_state <NegotiateStateFileName>]
          [--exe_mode SHUTDOWN|CONTINUE]
-         [--exe_conn VER_ONLY|VCA|DIGEST|CERT|CHAL|MEAS|MEL|GET_CSR|SET_CERT|GET_KEY_PAIR_INFO|SET_KEY_PAIR_INFO|EP_INFO]
+         [--exe_conn VER_ONLY|VCA|DIGEST|CERT|CHAL|MEAS|MEL|GET_CSR|SET_CERT|GET_KEY_PAIR_INFO|SET_KEY_PAIR_INFO|EP_INFO|SUPPORTED_ALGO]
          [--exe_session KEY_EX|PSK|NO_END|KEY_UPDATE|HEARTBEAT|MEAS|DIGEST|CERT|GET_CSR|SET_CERT|GET_KEY_PAIR_INFO|SET_KEY_PAIR_INFO|EP_INFO|APP]
          [--pcap <PcapFileName>]
          [--priv_key_mode PEM|RAW]
@@ -115,6 +115,9 @@ This document describes spdm_requester_emu and spdm_responder_emu tool. It can b
                  GET_KEY_PAIR_INFO means send GET_KEY_PAIR_INFO command.
                  SET_KEY_PAIR_INFO means send SET_KEY_PAIR_INFO command.
                  EP_INFO means send GET_ENDPOINT_INFO command.
+                 SUPPORTED_ALGO means request the Responder's SupportedAlgorithms block
+                     (DSP0274 1.3, GET_CAPABILITIES Param1[0] set) and print it, before
+                     continuing with the rest of the connection. Requires CHUNK_CAP on both sides.
          [--exe_session] is used to control the SPDM session. By default, it is KEY_EX,PSK,KEY_UPDATE,HEARTBEAT,MEAS,MEL,DIGEST,CERT,GET_CSR,SET_CERT,GET_KEY_PAIR_INFO,SET_KEY_PAIR_INFO,EP_INFO,APP.
                  KEY_EX means to setup KEY_EXCHANGE session.
                  PSK means to setup PSK_EXCHANGE session.

--- a/spdm_emu/spdm_emu_common/spdm_emu.c
+++ b/spdm_emu/spdm_emu_common/spdm_emu.c
@@ -86,7 +86,7 @@ void print_usage(const char *name)
     printf("   [--save_state <NegotiateStateFileName>]\n");
     printf("   [--load_state <NegotiateStateFileName>]\n");
     printf("   [--exe_mode SHUTDOWN|CONTINUE]\n");
-    printf("   [--exe_conn VER_ONLY|VCA|DIGEST|CERT|CHAL|MEAS|MEL|GET_CSR|SET_CERT|GET_KEY_PAIR_INFO|SET_KEY_PAIR_INFO|EP_INFO]\n");
+    printf("   [--exe_conn VER_ONLY|VCA|DIGEST|CERT|CHAL|MEAS|MEL|GET_CSR|SET_CERT|GET_KEY_PAIR_INFO|SET_KEY_PAIR_INFO|EP_INFO|SUPPORTED_ALGO]\n");
     printf("   [--exe_session KEY_EX|PSK|NO_END|KEY_UPDATE|HEARTBEAT|MEAS|MEL|DIGEST|CERT|GET_CSR|SET_CERT|GET_KEY_PAIR_INFO|SET_KEY_PAIR_INFO|EP_INFO|APP]\n");
     printf("   [--pcap <pcap_file_name>]\n");
     printf("   [--priv_key_mode PEM|RAW]\n");
@@ -495,6 +495,7 @@ value_string_entry_t m_exe_connection_string_table[] = {
     { EXE_CONNECTION_GET_KEY_PAIR_INFO, "GET_KEY_PAIR_INFO" },
     { EXE_CONNECTION_SET_KEY_PAIR_INFO, "SET_KEY_PAIR_INFO" },
     { EXE_CONNECTION_EP_INFO, "EP_INFO" },
+    { EXE_CONNECTION_SUPPORTED_ALGO, "SUPPORTED_ALGO" },
 };
 
 value_string_entry_t m_exe_session_string_table[] = {
@@ -565,6 +566,135 @@ bool get_flags_from_name(const value_string_entry_t *table,
 done:
     free(local_name);
     return ret;
+}
+
+/* Print the names of every bit set in "flags", looked up in "table". Bits without a
+ * matching table entry are printed as their raw hex value. Prints "NONE" if no bit is set. */
+static void dump_flag_names(const value_string_entry_t *table, size_t entry_count,
+                            uint32_t flags)
+{
+    size_t index;
+    uint32_t remaining;
+    bool first;
+
+    if (flags == 0) {
+        printf("NONE");
+        return;
+    }
+
+    remaining = flags;
+    first = true;
+    for (index = 0; index < entry_count; index++) {
+        if (table[index].value != 0 &&
+            (flags & table[index].value) == table[index].value) {
+            printf("%s%s", first ? "" : ",", table[index].name);
+            first = false;
+            remaining &= ~table[index].value;
+        }
+    }
+    if (remaining != 0) {
+        printf("%s0x%08x", first ? "" : ",", remaining);
+    }
+}
+
+void dump_supported_algorithms(const void *buffer, size_t buffer_size)
+{
+    const spdm_supported_algorithms_block_t *block;
+    const spdm_negotiate_algorithms_common_struct_table_t *alg_struct;
+    size_t index;
+
+    if (buffer_size < sizeof(spdm_supported_algorithms_block_t)) {
+        printf("SupportedAlgorithms: truncated (%u bytes)\n", (uint32_t)buffer_size);
+        return;
+    }
+    block = buffer;
+
+    printf("SupportedAlgorithms:\n");
+    printf("  AlgStructCount        - %d\n", block->param1);
+    printf("  Length                - %d\n", block->length);
+    printf("  MeasurementSpec       - ");
+    dump_flag_names(m_measurement_spec_value_string_table,
+                    LIBSPDM_ARRAY_SIZE(m_measurement_spec_value_string_table),
+                    block->measurement_specification);
+    printf("\n");
+    printf("  OtherParams           - ");
+    dump_flag_names(m_other_param_value_string_table,
+                    LIBSPDM_ARRAY_SIZE(m_other_param_value_string_table),
+                    block->other_params_support);
+    printf("\n");
+    printf("  BaseAsymAlgo          - ");
+    dump_flag_names(m_asym_value_string_table,
+                    LIBSPDM_ARRAY_SIZE(m_asym_value_string_table),
+                    block->base_asym_algo);
+    printf("\n");
+    printf("  BaseHashAlgo          - ");
+    dump_flag_names(m_hash_value_string_table,
+                    LIBSPDM_ARRAY_SIZE(m_hash_value_string_table),
+                    block->base_hash_algo);
+    printf("\n");
+    printf("  PqcAsymAlgo           - ");
+    dump_flag_names(m_pqc_asym_value_string_table,
+                    LIBSPDM_ARRAY_SIZE(m_pqc_asym_value_string_table),
+                    block->pqc_asym_algo);
+    printf("\n");
+    printf("  MelSpec               - ");
+    dump_flag_names(m_mel_spec_value_string_table,
+                    LIBSPDM_ARRAY_SIZE(m_mel_spec_value_string_table),
+                    block->mel_specification);
+    printf("\n");
+
+    alg_struct = (const spdm_negotiate_algorithms_common_struct_table_t *)(block + 1);
+    for (index = 0; index < block->param1; index++) {
+        /* Bounds-check each fixed-size AlgStruct table against the buffer. */
+        if ((const uint8_t *)(&alg_struct[index + 1]) >
+            ((const uint8_t *)buffer + buffer_size)) {
+            printf("  AlgStruct[%u]           - truncated\n", (uint32_t)index);
+            break;
+        }
+        switch (alg_struct[index].alg_type) {
+        case SPDM_NEGOTIATE_ALGORITHMS_STRUCT_TABLE_ALG_TYPE_DHE:
+            printf("  DHE                   - ");
+            dump_flag_names(m_dhe_value_string_table,
+                            LIBSPDM_ARRAY_SIZE(m_dhe_value_string_table),
+                            alg_struct[index].alg_supported);
+            break;
+        case SPDM_NEGOTIATE_ALGORITHMS_STRUCT_TABLE_ALG_TYPE_AEAD:
+            printf("  AEAD                  - ");
+            dump_flag_names(m_aead_value_string_table,
+                            LIBSPDM_ARRAY_SIZE(m_aead_value_string_table),
+                            alg_struct[index].alg_supported);
+            break;
+        case SPDM_NEGOTIATE_ALGORITHMS_STRUCT_TABLE_ALG_TYPE_REQ_BASE_ASYM_ALG:
+            printf("  ReqBaseAsymAlg        - ");
+            dump_flag_names(m_asym_value_string_table,
+                            LIBSPDM_ARRAY_SIZE(m_asym_value_string_table),
+                            alg_struct[index].alg_supported);
+            break;
+        case SPDM_NEGOTIATE_ALGORITHMS_STRUCT_TABLE_ALG_TYPE_KEY_SCHEDULE:
+            printf("  KeySchedule           - ");
+            dump_flag_names(m_key_schedule_value_string_table,
+                            LIBSPDM_ARRAY_SIZE(m_key_schedule_value_string_table),
+                            alg_struct[index].alg_supported);
+            break;
+        case SPDM_NEGOTIATE_ALGORITHMS_STRUCT_TABLE_ALG_TYPE_REQ_PQC_ASYM_ALG:
+            printf("  ReqPqcAsymAlg         - ");
+            dump_flag_names(m_pqc_asym_value_string_table,
+                            LIBSPDM_ARRAY_SIZE(m_pqc_asym_value_string_table),
+                            alg_struct[index].alg_supported);
+            break;
+        case SPDM_NEGOTIATE_ALGORITHMS_STRUCT_TABLE_ALG_TYPE_KEM_ALG:
+            printf("  KEM                   - ");
+            dump_flag_names(m_kem_value_string_table,
+                            LIBSPDM_ARRAY_SIZE(m_kem_value_string_table),
+                            alg_struct[index].alg_supported);
+            break;
+        default:
+            printf("  AlgType(0x%02x)          - 0x%04x",
+                   alg_struct[index].alg_type, alg_struct[index].alg_supported);
+            break;
+        }
+        printf("\n");
+    }
 }
 
 void process_args(char *program_name, int argc, char *argv[])

--- a/spdm_emu/spdm_emu_common/spdm_emu.h
+++ b/spdm_emu/spdm_emu_common/spdm_emu.h
@@ -109,6 +109,7 @@ extern uint32_t m_exe_mode;
 #define EXE_CONNECTION_GET_KEY_PAIR_INFO 0x100
 #define EXE_CONNECTION_SET_KEY_PAIR_INFO 0x200
 #define EXE_CONNECTION_EP_INFO 0x400
+#define EXE_CONNECTION_SUPPORTED_ALGO 0x800
 extern uint32_t m_exe_connection;
 
 #define EXE_SESSION_KEY_EX 0x1
@@ -176,6 +177,8 @@ void append_pcap_packet_data(const void *header, size_t header_size,
                              const void *data, size_t size);
 
 void process_args(char *program_name, int argc, char *argv[]);
+
+void dump_supported_algorithms(const void *buffer, size_t buffer_size);
 
 bool create_socket(uint16_t port_number, SOCKET *listen_socket);
 

--- a/spdm_emu/spdm_requester_emu/spdm_requester_spdm.c
+++ b/spdm_emu/spdm_requester_emu/spdm_requester_spdm.c
@@ -6,6 +6,11 @@
 
 #include "spdm_requester_emu.h"
 
+/* Internal libspdm API (declared in internal/libspdm_requester_lib.h, which cannot be
+ * included here without conflicting definitions); used by the SUPPORTED_ALGO probe to
+ * complete the VERSION/CAPABILITIES/ALGORITHMS sequence without repeating GET_VERSION. */
+libspdm_return_t libspdm_negotiate_algorithms(void *spdm_context);
+
 void *m_spdm_context;
 #if LIBSPDM_FIPS_MODE
 void *m_fips_selftest_context;
@@ -311,7 +316,36 @@ void *spdm_client_init(void)
     libspdm_set_data(spdm_context, LIBSPDM_DATA_KEM_ALG, &parameter,
                      &data32, sizeof(data32));
 
-    if (m_load_state_file_name == NULL) {
+    if ((m_exe_connection & EXE_CONNECTION_SUPPORTED_ALGO) != 0) {
+        /* Retrieve and print the Responder's SupportedAlgorithms block (GET_VERSION +
+         * GET_CAPABILITIES with Param1[0] set), then complete the same VERSION/CAPABILITIES/
+         * ALGORITHMS sequence with NEGOTIATE_ALGORITHMS. This reuses the one transcript
+         * already built by the block query; it is not reset or repeated. */
+        uint8_t supported_algs_buffer[LIBSPDM_MAX_SPDM_MSG_SIZE];
+        size_t supported_algs_length = sizeof(supported_algs_buffer);
+        uint8_t supported_algs_version = 0;
+
+        status = libspdm_get_supported_algorithms(
+            spdm_context, &supported_algs_length, supported_algs_buffer,
+            &supported_algs_version);
+        if (LIBSPDM_STATUS_IS_ERROR(status)) {
+            EMU_ERR("libspdm_get_supported_algorithms - 0x%x\n", (uint32_t)status);
+            free(m_spdm_context);
+            m_spdm_context = NULL;
+            return NULL;
+        }
+        printf("SupportedAlgorithms: SPDM version 0x%02x, %d bytes\n",
+               supported_algs_version, (uint32_t)supported_algs_length);
+        dump_supported_algorithms(supported_algs_buffer, supported_algs_length);
+
+        status = libspdm_negotiate_algorithms(spdm_context);
+        if (LIBSPDM_STATUS_IS_ERROR(status)) {
+            EMU_ERR("libspdm_negotiate_algorithms - 0x%x\n", (uint32_t)status);
+            free(m_spdm_context);
+            m_spdm_context = NULL;
+            return NULL;
+        }
+    } else if (m_load_state_file_name == NULL) {
         /* Skip if state is loaded*/
         status = libspdm_init_connection(
             spdm_context,


### PR DESCRIPTION
Add an --exe_conn SUPPORTED_ALGO mode that calls
libspdm_get_supported_algorithms() to query the Responder's SupportedAlgorithms block (DSP0274 1.3 SUPPORTED_ALGOS_EXT_CAP, GET_CAPABILITIES Param1 bit 0), then prints the returned block as a human-readable algorithm list and exits without authentication/session (no algorithms are negotiated).

The block is decoded via a new dump_supported_algorithms() helper that reuses the existing algorithm name tables (asym/hash/dhe/aead/pqc_asym/ kem/key_schedule/measurement_spec), printing each field and AlgStruct table by name.

This enables cross-testing a Responder-under-test that implements the SupportedAlgorithms extended capability, which the stock requester emu flow (libspdm_init_connection) does not exercise.


Assisted-by: Claude:claude-opus-4-8