### PR TITLE
Make SPDM-Responder-Validator submodule optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,7 @@ set(DEVICE ${DEVICE} CACHE STRING "Choose the test device: sample tpm, and defau
 
 option(LIBSPDM_TPM_SUPPORT "Add TPM support in crypt_ext" OFF)
 option(USE_SYSTEM_LIBSPDM "Use system provided libspdm" OFF)
+option(BUILD_VALIDATOR_SAMPLES "Build SPDM validator and attester samples (requires SPDM-Responder-Validator submodule)" ON)
 
 if(NOT GCOV)
     set(GCOV "OFF")
@@ -30,8 +31,11 @@ if (NOT DEVICE)
 endif()
 
 set(SPDM_EMU_DIR ${PROJECT_SOURCE_DIR})
-set(SPDM_RESPONDER_VALIDATOR_DIR ${PROJECT_SOURCE_DIR}/SPDM-Responder-Validator)
-set(COMMON_TEST_FRAMEWORK_DIR ${PROJECT_SOURCE_DIR}/SPDM-Responder-Validator/common_test_framework)
+
+if(BUILD_VALIDATOR_SAMPLES)
+    set(SPDM_RESPONDER_VALIDATOR_DIR ${PROJECT_SOURCE_DIR}/SPDM-Responder-Validator)
+    set(COMMON_TEST_FRAMEWORK_DIR ${PROJECT_SOURCE_DIR}/SPDM-Responder-Validator/common_test_framework)
+endif()
 
 if (USE_SYSTEM_LIBSPDM)
   find_package(PkgConfig REQUIRED)
@@ -728,9 +732,10 @@ endif (NOT USE_SYSTEM_LIBSPDM)
     add_subdirectory(spdm_emu/spdm_requester_emu)
     add_subdirectory(spdm_emu/spdm_responder_emu)
 
-    add_subdirectory(${COMMON_TEST_FRAMEWORK_DIR}/library/common_test_utility_lib out/common_test_utility_lib.out)
-    add_subdirectory(${SPDM_RESPONDER_VALIDATOR_DIR}/library/spdm_responder_conformance_test_lib out/spdm_responder_conformance_test_lib.out)
-    add_subdirectory(spdm_emu/spdm_device_validator_sample)
-
-    add_subdirectory(spdm_emu/spdm_device_attester_sample)
+    if(BUILD_VALIDATOR_SAMPLES)
+        add_subdirectory(${COMMON_TEST_FRAMEWORK_DIR}/library/common_test_utility_lib out/common_test_utility_lib.out)
+        add_subdirectory(${SPDM_RESPONDER_VALIDATOR_DIR}/library/spdm_responder_conformance_test_lib out/spdm_responder_conformance_test_lib.out)
+        add_subdirectory(spdm_emu/spdm_device_validator_sample)
+        add_subdirectory(spdm_emu/spdm_device_attester_sample)
+    endif()
     endif()

--- a/README.md
+++ b/README.md
@@ -64,6 +64,16 @@ TPM-backed SPDM flows require additional dependencies.
    make
    ```
 
+### Optional: Use System libspdm
+
+By default, spdm-emu builds libspdm from the submodule. To use a system-installed libspdm instead:
+
+```
+  -DUSE_SYSTEM_LIBSPDM=ON
+```
+
+This requires libspdm to be installed and available via pkg-config.
+
 ### Optional: Enable TPM Support
 
 To build spdm-emu with TPM-backed device secret support:
@@ -72,6 +82,30 @@ To build spdm-emu with TPM-backed device secret support:
   -DDEVICE=tpm
   -DLIBSPDM_TPM_SUPPORT=ON
 ```
+
+### Optional: Build SPDM Validator Samples
+
+The SPDM-Responder-Validator submodule provides conformance testing tools (`spdm_device_validator_sample` and `spdm_device_attester_sample`). These are **enabled by default** and require the SPDM-Responder-Validator submodule to be initialized.
+
+**To build with validator samples (default):**
+```bash
+# Ensure the SPDM-Responder-Validator submodule is initialized
+git submodule update --init SPDM-Responder-Validator
+
+cmake -DARCH=x64 -DTOOLCHAIN=GCC -DTARGET=Release -DCRYPTO=openssl ..
+make
+# Builds: spdm_requester_emu, spdm_responder_emu, spdm_device_validator_sample, spdm_device_attester_sample
+```
+
+**To build without validator samples:**
+```bash
+# No need to initialize the SPDM-Responder-Validator submodule
+cmake -DARCH=x64 -DTOOLCHAIN=GCC -DTARGET=Release -DCRYPTO=openssl -DBUILD_VALIDATOR_SAMPLES=OFF ..
+make
+# Builds: spdm_requester_emu, spdm_responder_emu
+```
+
+**Note:** The validator samples are primarily used for SPDM responder conformance testing and are not required for basic SPDM emulator functionality. Disable them with `-DBUILD_VALIDATOR_SAMPLES=OFF` (e.g. in submodule-free build environments like Yocto).
 
 ### TPM Setup (Optional)
 


### PR DESCRIPTION
Add BUILD_VALIDATOR_SAMPLES CMake option (default: ON) to allow
building the main SPDM emulators without the SPDM-Responder-Validator
submodule.

Changes:
   - Add BUILD_VALIDATOR_SAMPLES option to CMakeLists.txt
   - Guard the SPDM_RESPONDER_VALIDATOR_DIR / COMMON_TEST_FRAMEWORK_DIR
       paths and the validator library/sample builds behind the option
   -  Document BUILD_VALIDATOR_SAMPLES and USE_SYSTEM_LIBSPDM in README.md

This allows spdm_requester_emu and spdm_responder_emu to build without the
SPDM-Responder-Validator submodule when explicitly requested with
-DBUILD_VALIDATOR_SAMPLES=OFF. Otherwise the validator and attester samples
are built normally after initialising the submodule.

Fixes #507 