### PR TITLE
build: fix spdm-emu build errors against system libspdm

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,10 +40,12 @@ endif()
 if (USE_SYSTEM_LIBSPDM)
   find_package(PkgConfig REQUIRED)
   pkg_check_modules(LIBSPDM REQUIRED libspdm)
-  pkg_get_variable(_LIBSPDM_INCLUDE_PATH libspdm includedir)
-  include_directories(
-    "${_LIBSPDM_INCLUDE_PATH}/include"
-  )
+  include_directories(${LIBSPDM_INCLUDE_DIRS})
+  link_directories(${LIBSPDM_LIBRARY_DIRS})
+  # The installed libspdm exports its configuration
+  # macros (-DLIBSPDM_*) through pkg-config.
+  add_definitions(${LIBSPDM_CFLAGS_OTHER})
+  list(APPEND LIBSPDM_LIBRARIES spdm_device_secret_lib_${DEVICE})
 else (USE_SYSTEM_LIBSPDM)
   set(LIBSPDM_DIR "${PROJECT_SOURCE_DIR}/libspdm")
   include_directories(
@@ -455,7 +457,15 @@ if(CMAKE_SYSTEM_NAME MATCHES "Linux")
         set(CMAKE_C_LINK_EXECUTABLE "")
 
     elseif(TOOLCHAIN STREQUAL "NONE")
-        set(CMAKE_C_LINK_EXECUTABLE   "<CMAKE_C_COMPILER> <FLAGS> <CMAKE_C_LINK_FLAGS> <LINK_FLAGS> <OBJECTS> -o <TARGET> -static -Wl,--start-group <LINK_LIBRARIES> -Wl,--end-group")
+        if(USE_SYSTEM_LIBSPDM)
+            # Link the system libspdm and its dependencies (OpenSSL, TSS2, libc).
+            # Don't force -static: the system generally has no static archives
+            # for those, so a fully-static link would fail.
+            set(CMAKE_C_LINK_EXECUTABLE   "<CMAKE_C_COMPILER> <FLAGS> <CMAKE_C_LINK_FLAGS> <LINK_FLAGS> <OBJECTS> -o <TARGET> -Wl,--start-group <LINK_LIBRARIES> -Wl,--end-group")
+        else()
+            # When using submodule libspdm, use static linking
+            set(CMAKE_C_LINK_EXECUTABLE   "<CMAKE_C_COMPILER> <FLAGS> <CMAKE_C_LINK_FLAGS> <LINK_FLAGS> <OBJECTS> -o <TARGET> -static -Wl,--start-group <LINK_LIBRARIES> -Wl,--end-group")
+        endif()
 
     endif()
 
@@ -657,24 +667,28 @@ set(EXECUTABLE_OUTPUT_PATH ${PROJECT_BINARY_DIR}/bin)
 
 add_custom_target(copy_sample_key)
 
-if(CMAKE_SYSTEM_NAME MATCHES "Linux")
-    add_custom_command(TARGET copy_sample_key
-                    PRE_BUILD
-                    COMMAND cp -r -f ${LIBSPDM_DIR}/unit_test/sample_key/* ${EXECUTABLE_OUTPUT_PATH})
-elseif(CMAKE_SYSTEM_NAME MATCHES "Windows")
-    STRING(REPLACE "/" "\\" SRC ${LIBSPDM_DIR}/unit_test/sample_key/*)
-    if(CMAKE_GENERATOR MATCHES "^Visual Studio")
-        if(CMAKE_BUILD_TYPE STREQUAL "Debug")
-            STRING(REPLACE "/" "\\" DEST ${EXECUTABLE_OUTPUT_PATH}/Debug)
+if(NOT USE_SYSTEM_LIBSPDM)
+    if(CMAKE_SYSTEM_NAME MATCHES "Linux")
+        add_custom_command(TARGET copy_sample_key
+                        PRE_BUILD
+                        COMMAND cp -r -f ${LIBSPDM_DIR}/unit_test/sample_key/* ${EXECUTABLE_OUTPUT_PATH})
+    elseif(CMAKE_SYSTEM_NAME MATCHES "Windows")
+        STRING(REPLACE "/" "\\" SRC ${LIBSPDM_DIR}/unit_test/sample_key/*)
+        if(CMAKE_GENERATOR MATCHES "^Visual Studio")
+            if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+                STRING(REPLACE "/" "\\" DEST ${EXECUTABLE_OUTPUT_PATH}/Debug)
+            else()
+                STRING(REPLACE "/" "\\" DEST ${EXECUTABLE_OUTPUT_PATH}/Release)
+            endif()
         else()
-            STRING(REPLACE "/" "\\" DEST ${EXECUTABLE_OUTPUT_PATH}/Release)
+            STRING(REPLACE "/" "\\" DEST ${EXECUTABLE_OUTPUT_PATH})
         endif()
-    else()
-        STRING(REPLACE "/" "\\" DEST ${EXECUTABLE_OUTPUT_PATH})
+        add_custom_command(TARGET copy_sample_key
+                           PRE_BUILD
+                           COMMAND xcopy /y /s ${SRC} ${DEST})
     endif()
-    add_custom_command(TARGET copy_sample_key
-                       PRE_BUILD
-                       COMMAND xcopy /y /s ${SRC} ${DEST})
+else()
+    message(STATUS "Using system libspdm - sample keys not copied.")
 endif()
 
 if (NOT USE_SYSTEM_LIBSPDM)

--- a/spdm_emu/spdm_device_attester_sample/CMakeLists.txt
+++ b/spdm_emu/spdm_device_attester_sample/CMakeLists.txt
@@ -2,11 +2,16 @@ cmake_minimum_required(VERSION 3.5)
 
 include_directories(${PROJECT_SOURCE_DIR}/spdm_emu/spdm_emu_common
                     ${PROJECT_SOURCE_DIR}/include
-                    ${LIBSPDM_DIR}/os_stub/spdm_device_secret_lib_${DEVICE}
-                    ${LIBSPDM_DIR}/include
-                    ${LIBSPDM_DIR}/os_stub/include
-                    ${LIBSPDM_DIR}/os_stub
 )
+
+if(NOT USE_SYSTEM_LIBSPDM)
+    include_directories(
+        ${LIBSPDM_DIR}/os_stub/spdm_device_secret_lib_${DEVICE}
+        ${LIBSPDM_DIR}/include
+        ${LIBSPDM_DIR}/os_stub/include
+        ${LIBSPDM_DIR}/os_stub
+    )
+endif()
 
 set(src_spdm_device_attester_sample
     spdm_device_attester_sample.c

--- a/spdm_emu/spdm_device_validator_sample/CMakeLists.txt
+++ b/spdm_emu/spdm_device_validator_sample/CMakeLists.txt
@@ -3,13 +3,18 @@ cmake_minimum_required(VERSION 3.5)
 include_directories(${PROJECT_SOURCE_DIR}/spdm_emu/spdm_responder_test_client
                     ${PROJECT_SOURCE_DIR}/spdm_emu/spdm_emu_common
                     ${PROJECT_SOURCE_DIR}/include
-                    ${LIBSPDM_DIR}/os_stub/spdm_device_secret_lib_${DEVICE}
-                    ${LIBSPDM_DIR}/include
-                    ${LIBSPDM_DIR}/os_stub/include
-                    ${LIBSPDM_DIR}/os_stub
                     ${SPDM_RESPONDER_VALIDATOR_DIR}/include
                     ${COMMON_TEST_FRAMEWORK_DIR}/include
 )
+
+if(NOT USE_SYSTEM_LIBSPDM)
+    include_directories(
+        ${LIBSPDM_DIR}/os_stub/spdm_device_secret_lib_${DEVICE}
+        ${LIBSPDM_DIR}/include
+        ${LIBSPDM_DIR}/os_stub/include
+        ${LIBSPDM_DIR}/os_stub
+    )
+endif()
 
 set(src_spdm_device_validator_sample
     spdm_device_validator_sample.c

--- a/spdm_emu/spdm_emu_common/spdm_emu.h
+++ b/spdm_emu/spdm_emu_common/spdm_emu.h
@@ -9,6 +9,7 @@
 
 #include "hal/base.h"
 #include "hal/library/memlib.h"
+#include "hal/library/debuglib.h"
 #include "library/spdm_common_lib.h"
 #include "internal/libspdm_device_secret_lib.h"
 

--- a/spdm_emu/spdm_requester_emu/CMakeLists.txt
+++ b/spdm_emu/spdm_requester_emu/CMakeLists.txt
@@ -3,11 +3,16 @@ cmake_minimum_required(VERSION 3.5)
 include_directories(${PROJECT_SOURCE_DIR}/spdm_emu/spdm_requester_emu
                     ${PROJECT_SOURCE_DIR}/spdm_emu/spdm_emu_common
                     ${PROJECT_SOURCE_DIR}/include
-                    ${LIBSPDM_DIR}/os_stub/spdm_device_secret_lib_${DEVICE}
-                    ${LIBSPDM_DIR}/include
-                    ${LIBSPDM_DIR}/os_stub/include
-                    ${LIBSPDM_DIR}/os_stub
 )
+
+if(NOT USE_SYSTEM_LIBSPDM)
+    include_directories(
+        ${LIBSPDM_DIR}/os_stub/spdm_device_secret_lib_${DEVICE}
+        ${LIBSPDM_DIR}/include
+        ${LIBSPDM_DIR}/os_stub/include
+        ${LIBSPDM_DIR}/os_stub
+    )
+endif()
 
 set(src_spdm_requester_emu
     spdm_requester_spdm.c

--- a/spdm_emu/spdm_requester_emu/spdm_requester_measurement.c
+++ b/spdm_emu/spdm_requester_emu/spdm_requester_measurement.c
@@ -185,6 +185,7 @@ libspdm_return_t do_measurement_via_spdm(const uint32_t *session_id)
     return LIBSPDM_STATUS_SUCCESS;
 }
 
+#if LIBSPDM_ENABLE_CAPABILITY_MEL_CAP
 /**
  * This function executes SPDM measurement MEL.
  *
@@ -220,5 +221,6 @@ libspdm_return_t do_measurement_mel_via_spdm(const uint32_t *session_id)
 
     return LIBSPDM_STATUS_SUCCESS;
 }
+#endif /*LIBSPDM_ENABLE_CAPABILITY_MEL_CAP*/
 
 #endif /*LIBSPDM_ENABLE_CAPABILITY_MEAS_CAP*/

--- a/spdm_emu/spdm_responder_emu/CMakeLists.txt
+++ b/spdm_emu/spdm_responder_emu/CMakeLists.txt
@@ -3,11 +3,16 @@ cmake_minimum_required(VERSION 3.5)
 include_directories(${PROJECT_SOURCE_DIR}/spdm_emu/spdm_responder_emu
                     ${PROJECT_SOURCE_DIR}/spdm_emu/spdm_emu_common
                     ${PROJECT_SOURCE_DIR}/include
-                    ${LIBSPDM_DIR}/os_stub/spdm_device_secret_lib_${DEVICE}
-                    ${LIBSPDM_DIR}/include
-                    ${LIBSPDM_DIR}/os_stub/include
-                    ${LIBSPDM_DIR}/os_stub
 )
+
+if(NOT USE_SYSTEM_LIBSPDM)
+    include_directories(
+        ${LIBSPDM_DIR}/os_stub/spdm_device_secret_lib_${DEVICE}
+        ${LIBSPDM_DIR}/include
+        ${LIBSPDM_DIR}/os_stub/include
+        ${LIBSPDM_DIR}/os_stub
+    )
+endif()
 
 set(src_spdm_responder_emu
     spdm_responder_spdm.c


### PR DESCRIPTION
Fix several compilation errors that occur when building spdm-emu against system-installed libspdm, mostly on Yocto build environment. The main changes are:
1. The previous pkg_get_variable approach returned un-sysrooted paths that broke cross-compilation, use LIBSPDM_INCLUDE_DIRS/LIBSPDM_LIBRARY_DIRS
2. Gate the submodule-only include directories (${LIBSPDM_DIR}/...) behind NOT USE_SYSTEM_LIBSPDM in the emu and CMakeLists.
3. Skip copy_sample_key for the system build, where the bundled sample keys are not available; it still runs for the submodule build.
4. Include hal/library/debuglib.h in spdm_emu.h; it is no longer pulled in through the installed headers.
5. Guard do_measurement_mel_via_spdm() with LIBSPDM_ENABLE_CAPABILITY_MEL_CAP to match its call sites, so it is not compiled when that capability is disabled through the propagated configuration macros.