### PR TITLE
Proposal for support for the Linux kernel MCTP stack

### DIFF
--- a/doc/spdm_emu.md
+++ b/doc/spdm_emu.md
@@ -5,10 +5,12 @@ This document describes spdm_requester_emu and spdm_responder_emu tool. It can b
 ## Spdm OS tool user guide
 
    ```
-      spdm_requester_emu|spdm_responder_emu [--trans MCTP|PCI_DOE|TCP|NONE]
+      spdm_requester_emu|spdm_responder_emu [--trans MCTP|PCI_DOE|TCP|MCTP_KERNEL|NONE]
          [--tcp_sub RI|NO_RI]
          [--ip <ip_address>]
          [--port <port_number>]
+         [--eid <MCTP endpoint identifier>]
+         [--net <MCTP network identifier>]
          [--ver 1.0|1.1|1.2|1.3|1.4]
          [--sec_ver 1.0|1.1|1.2]
          [--cap CACHE|CERT|CHAL|MEAS_NO_SIG|MEAS_SIG|MEAS_FRESH|ENCRYPT|MAC|MUT_AUTH|KEY_EX|PSK|PSK_WITH_CONTEXT|ENCAP|HBEAT|KEY_UPD|HANDSHAKE_IN_CLEAR|PUB_KEY_ID|CHUNK|ALIAS_CERT|SET_CERT|CSR|CERT_INSTALL_RESET|EP_INFO_NO_SIG|EP_INFO_SIG|MEL|EVENT|MULTI_KEY_ONLY|MULTI_KEY_NEG|GET_KEY_PAIR_INFO|SET_KEY_PAIR_INFO|SET_KEY_PAIR_RESET|LARGE_RESP]
@@ -47,11 +49,22 @@ This document describes spdm_requester_emu and spdm_responder_emu tool. It can b
 
       NOTE:
          [--trans] is used to select transport layer message. By default, MCTP is used.
+                 MCTP_KERNEL uses the Linux kernel AF_MCTP socket (CONFIG_MCTP) instead of
+                 the emulated TCP-based transport. Selecting MCTP_KERNEL on non-Linux
+                 platforms is rejected at runtime.
          [--tcp_sub] is sub-option when transport layer is TCP. By default, NO_RI (No RoleInquiry) is used.
          [--ip] is the IPv4 address for the connection. By default, 127.0.0.1 is used.
                  For Requester, it is the address to connect to.
                  For Responder, it is the address to bind to. If not specified, the Responder binds to all interfaces.
          [--port] is the port number for the connection. By default, 2323 is used for MCTP/PCI_DOE and 4194 is used for TCP.
+         [--eid] is the MCTP Endpoint Identifier used with MCTP_KERNEL transport (Linux only).
+                 For Requester, it is the destination EID of the remote SPDM responder.
+                 Valid unicast range: 1~254. EID 0x00 (Null) and 0xFF (Broadcast) are rejected.
+                 Defined in DMTF DSP0236.
+         [--net] is the MCTP network identifier used with MCTP_KERNEL transport (Linux only).
+                 Selects the target MCTP network when multiple networks coexist on the same host.
+                 By default, MCTP_NET_ANY (0) is used and the kernel selects the network automatically.
+                 Defined in DMTF DSP0236.
          [--ver] is version. By default, all are used.
          [--sec_ver] is secured message version. By default, all are used.
          [--cap] is capability flags. Multiple flags can be set together. Please use ',' for them.

--- a/spdm_emu/spdm_emu_common/command.c
+++ b/spdm_emu/spdm_emu_common/command.c
@@ -34,6 +34,14 @@ size_t m_send_receive_buffer_size;
  */
 static struct sockaddr_mctp m_mctp_recv_addr;
 static bool m_mctp_recv_addr_valid = false;
+
+/* Reset the stored peer address.  Call when opening a new socket so that
+ * write_bytes() starts in the requester state rather than reusing leftover
+ * state from a previous session. */
+void mctp_kernel_reset_peer_addr(void)
+{
+    m_mctp_recv_addr_valid = false;
+}
 #endif
 
 /**
@@ -130,7 +138,21 @@ bool read_multiple_bytes(const SOCKET socket, uint8_t *buffer,
         rc = recvfrom(socket, (char *)(buffer + 1), max_buffer_length - 1, 0,
                       (struct sockaddr *)&addr, &addrlen);
         if (rc < 0) {
+            /*
+             * Edge case: recvfrom error.  Invalidate any previously stored
+             * peer address so write_bytes does not reuse stale state.
+             */
+            m_mctp_recv_addr_valid = false;
             EMU_ERR("MCTP recvfrom error: %s\n", strerror(errno));
+            return false;
+        }
+        if (rc == 0) {
+            /*
+             * Edge case: empty datagram.  The peer address captured from a
+             * zero-length recvfrom() is not meaningful for a reply.
+             */
+            m_mctp_recv_addr_valid = false;
+            EMU_ERR("MCTP recvfrom: empty datagram\n");
             return false;
         }
 
@@ -319,45 +341,73 @@ bool write_bytes(const SOCKET socket, const uint8_t *buffer,
     uint32_t number_sent;
 
     number_sent = 0;
-    while (number_sent < number_of_bytes) {
 #ifndef _MSC_VER
-        if (m_use_transport_layer == SOCKET_TRANSPORT_TYPE_MCTP_LINUX_KERNEL) {
-            struct sockaddr_mctp addr = { 0 };
-            addr.smctp_family = AF_MCTP;
-            addr.smctp_type = MCTP_MESSAGE_TYPE_SPDM;
+    if (m_use_transport_layer == SOCKET_TRANSPORT_TYPE_MCTP_LINUX_KERNEL) {
+        /*
+         * Capture the role (responder vs. requester) once before the send
+         * loop.  Evaluating m_mctp_recv_addr_valid inside the loop would
+         * produce inconsistent addresses across iterations if the flag were
+         * cleared mid-loop.
+         */
+        bool is_responder_reply = (m_mctp_recv_addr_valid &&
+                                   (m_mctp_recv_addr.smctp_tag & MCTP_TAG_OWNER));
+        struct sockaddr_mctp addr = { 0 };
+        addr.smctp_family = AF_MCTP;
+        addr.smctp_type = MCTP_MESSAGE_TYPE_SPDM;
 
-            if (m_mctp_recv_addr_valid &&
-                (m_mctp_recv_addr.smctp_tag & MCTP_TAG_OWNER)) {
-                /*
-                 * The last received message carried MCTP_TAG_OWNER, meaning
-                 * the remote peer owns the tag.  We are the responder; reply
-                 * to the requester using the same network, EID, and tag value
-                 * but with MCTP_TAG_OWNER cleared (DSP0236 §8.17).
-                 */
-                addr.smctp_network = m_mctp_recv_addr.smctp_network;
-                addr.smctp_addr.s_addr = m_mctp_recv_addr.smctp_addr.s_addr;
-                addr.smctp_tag = m_mctp_recv_addr.smctp_tag & MCTP_TAG_MASK;
-            } else {
-                /*
-                 * We are the requester initiating a new transaction.  Set
-                 * MCTP_TAG_OWNER so the kernel allocates a tag and routes the
-                 * response back to this socket (DSP0236 §8.17).
-                 */
-                addr.smctp_network = m_use_net;
-                addr.smctp_addr.s_addr = m_use_eid;
-                addr.smctp_tag = MCTP_TAG_OWNER;
-            }
+        if (is_responder_reply) {
+            /*
+             * The last received message carried MCTP_TAG_OWNER, meaning
+             * the remote peer owns the tag.  We are the responder; reply
+             * to the requester using the same network, EID, and tag value
+             * but with MCTP_TAG_OWNER cleared (DSP0236 §8.17).
+             */
+            addr.smctp_network = m_mctp_recv_addr.smctp_network;
+            addr.smctp_addr.s_addr = m_mctp_recv_addr.smctp_addr.s_addr;
+            addr.smctp_tag = m_mctp_recv_addr.smctp_tag & MCTP_TAG_MASK;
+        } else {
+            /*
+             * We are the requester initiating a new transaction.  Set
+             * MCTP_TAG_OWNER so the kernel allocates a tag and routes the
+             * response back to this socket (DSP0236 §8.17).
+             */
+            addr.smctp_network = m_use_net;
+            addr.smctp_addr.s_addr = m_use_eid;
+            addr.smctp_tag = MCTP_TAG_OWNER;
+        }
 
+        while (number_sent < number_of_bytes) {
             result = sendto(socket, (char *)(buffer + number_sent),
                             number_of_bytes - number_sent, 0,
                             (struct sockaddr *)&addr, sizeof(addr));
-        } else {
-#endif
-            result = send(socket, (char *)(buffer + number_sent),
-                          number_of_bytes - number_sent, 0);
-#ifndef _MSC_VER
+            if (result == -1) {
+                /*
+                 * Edge case: send failure.  Clear the valid flag so the
+                 * next write_bytes does not reuse a stale peer address.
+                 */
+                if (is_responder_reply)
+                    m_mctp_recv_addr_valid = false;
+                EMU_ERR("Send error - 0x%x\n", socket_errno());
+                return false;
+            }
+            number_sent += result;
         }
+
+        /*
+         * Edge case: reply sent successfully.  The MCTP message tag is now
+         * consumed by the kernel.  Reset the valid flag so write_bytes
+         * cannot accidentally reuse this peer address before the next
+         * recvfrom() delivers a fresh request.
+         */
+        if (is_responder_reply)
+            m_mctp_recv_addr_valid = false;
+
+        return true;
+    }
 #endif
+    while (number_sent < number_of_bytes) {
+        result = send(socket, (char *)(buffer + number_sent),
+                      number_of_bytes - number_sent, 0);
         if (result == -1) {
 #ifdef _WIN32
             if (WSAGetLastError() == 0x2745) {

--- a/spdm_emu/spdm_emu_common/command.c
+++ b/spdm_emu/spdm_emu_common/command.c
@@ -1,6 +1,6 @@
 /**
  *  Copyright Notice:
- *  Copyright 2021-2025 DMTF. All rights reserved.
+ *  Copyright 2021-2026 DMTF. All rights reserved.
  *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/spdm-emu/blob/main/LICENSE.md
  **/
 
@@ -8,11 +8,6 @@
 
 /* hack to add MCTP header for PCAP*/
 #include "industry_standard/mctp.h"
-
-#ifndef _MSC_VER
-#include <linux/mctp.h>
-#include <errno.h>
-#endif
 
 uint32_t m_use_transport_layer = SOCKET_TRANSPORT_TYPE_MCTP;
 
@@ -22,27 +17,36 @@ bool m_send_receive_buffer_acquired = false;
 uint8_t m_send_receive_buffer[LIBSPDM_MAX_SENDER_RECEIVER_BUFFER_SIZE];
 size_t m_send_receive_buffer_size;
 
-#ifndef _MSC_VER
-/*
- * Peer address captured by the last recvfrom() on an AF_MCTP socket.
- *
- * The responder reads this after receiving a request; the tag field retains
- * MCTP_TAG_OWNER so write_bytes() can detect the direction and reply
- * correctly (TO cleared).  The requester overwrites it with the responder's
- * address on each response but re-builds the destination from m_use_eid /
- * m_use_net on every new outgoing request (MCTP_TAG_OWNER set).
- */
-static struct sockaddr_mctp m_mctp_recv_addr;
-static bool m_mctp_recv_addr_valid = false;
+/* Forward declarations for the default (socket-framed) IO ops - see the
+ * spdm_emu_io_ops_t vtable declared in command.h. */
+static bool default_recv_command(SOCKET socket, uint32_t *command);
+static bool default_recv_transport_type(SOCKET socket, uint32_t *transport_type);
+static bool default_recv_payload(SOCKET socket, uint8_t *buffer,
+                                 uint32_t *bytes_received,
+                                 uint32_t max_buffer_length);
+static bool default_send_payload(SOCKET socket, uint32_t command,
+                                 const uint8_t *buffer,
+                                 uint32_t bytes_to_send);
 
-/* Reset the stored peer address.  Call when opening a new socket so that
- * write_bytes() starts in the requester state rather than reusing leftover
- * state from a previous session. */
-void mctp_kernel_reset_peer_addr(void)
+static const spdm_emu_io_ops_t default_socket_io_ops = {
+    default_recv_command,
+    default_recv_transport_type,
+    default_recv_payload,
+    default_send_payload,
+};
+
+/*
+ * Active IO ops.  Defaults to the built-in socket (TCP/MCTP/PCI_DOE) framing
+ * implementation.  A platform-specific transport (e.g. the Linux kernel
+ * AF_MCTP socket) registers its own ops via spdm_emu_io_ops_register()
+ * before its first send/receive call.
+ */
+static const spdm_emu_io_ops_t *g_io_ops = &default_socket_io_ops;
+
+void spdm_emu_io_ops_register(const spdm_emu_io_ops_t *ops)
 {
-    m_mctp_recv_addr_valid = false;
+    g_io_ops = (ops != NULL) ? ops : &default_socket_io_ops;
 }
-#endif
 
 /**
  * Read number of bytes data in blocking mode.
@@ -58,24 +62,8 @@ bool read_bytes(const SOCKET socket, uint8_t *buffer,
 
     number_received = 0;
     while (number_received < number_of_bytes) {
-#ifndef _MSC_VER
-        if (m_use_transport_layer == SOCKET_TRANSPORT_TYPE_MCTP_LINUX_KERNEL) {
-            struct sockaddr_mctp addr;
-            socklen_t addrlen = sizeof(addr);
-            result = recvfrom(socket, (char *)(buffer + number_received),
-                              number_of_bytes - number_received, 0,
-                              (struct sockaddr *)&addr, &addrlen);
-            if (result > 0) {
-                m_mctp_recv_addr = addr;
-                m_mctp_recv_addr_valid = true;
-            }
-        } else {
-#endif
-            result = recv(socket, (char *)(buffer + number_received),
-                          number_of_bytes - number_received, 0);
-#ifndef _MSC_VER
-        }
-#endif
+        result = recv(socket, (char *)(buffer + number_received),
+                      number_of_bytes - number_received, 0);
         if (result == -1) {
             EMU_ERR("Receive error - 0x%x\n", socket_errno());
             return false;
@@ -113,62 +101,21 @@ bool read_multiple_bytes(const SOCKET socket, uint8_t *buffer,
                          uint32_t *bytes_received,
                          uint32_t max_buffer_length)
 {
+    return g_io_ops->recv_payload(socket, buffer, bytes_received,
+                                  max_buffer_length);
+}
+
+/**
+ * Default (socket-framed) recv_payload implementation: a 4-byte big-endian
+ * length prefix followed by the payload.  Used by TCP, MCTP (TCP-emulated),
+ * and PCI_DOE transports.
+ **/
+static bool default_recv_payload(const SOCKET socket, uint8_t *buffer,
+                                 uint32_t *bytes_received,
+                                 uint32_t max_buffer_length)
+{
     uint32_t length;
     bool result;
-
-#ifndef _MSC_VER
-    if (m_use_transport_layer == SOCKET_TRANSPORT_TYPE_MCTP_LINUX_KERNEL) {
-        /*
-         * The Linux kernel AF_MCTP socket delivers one complete MCTP message
-         * per recvfrom() call.  The message type byte is carried in
-         * sockaddr_mctp.smctp_type by the kernel and is NOT present in the
-         * payload.  libspdm's MCTP transport layer, however, expects buffer[0]
-         * to be the IC+MessageType byte (0x05 for SPDM).  We therefore receive
-         * into buffer+1 and prepend the type byte ourselves.
-         */
-        struct sockaddr_mctp addr;
-        socklen_t addrlen = sizeof(addr);
-        int32_t rc;
-
-        if (max_buffer_length < 2) {
-            EMU_ERR("buffer too small for MCTP receive\n");
-            return false;
-        }
-
-        rc = recvfrom(socket, (char *)(buffer + 1), max_buffer_length - 1, 0,
-                      (struct sockaddr *)&addr, &addrlen);
-        if (rc < 0) {
-            /*
-             * Edge case: recvfrom error.  Invalidate any previously stored
-             * peer address so write_bytes does not reuse stale state.
-             */
-            m_mctp_recv_addr_valid = false;
-            EMU_ERR("MCTP recvfrom error: %s\n", strerror(errno));
-            return false;
-        }
-        if (rc == 0) {
-            /*
-             * Edge case: empty datagram.  The peer address captured from a
-             * zero-length recvfrom() is not meaningful for a reply.
-             */
-            m_mctp_recv_addr_valid = false;
-            EMU_ERR("MCTP recvfrom: empty datagram\n");
-            return false;
-        }
-
-        m_mctp_recv_addr = addr;
-        m_mctp_recv_addr_valid = true;
-
-        /* Prepend the message type byte expected by the MCTP transport layer. */
-        buffer[0] = MCTP_MESSAGE_TYPE_SPDM;
-        *bytes_received = (uint32_t)rc + 1;
-
-        EMU_LOG("Platform port Receive buffer (MCTP kernel):\n    ");
-        dump_data(buffer, *bytes_received);
-        EMU_LOG("\n");
-        return true;
-    }
-#endif
 
     result = read_data32(socket, &length);
     if (!result) {
@@ -202,20 +149,16 @@ bool read_multiple_bytes(const SOCKET socket, uint8_t *buffer,
 
 bool receive_platform_command(const SOCKET socket, uint32_t *command)
 {
+    return g_io_ops->recv_command(socket, command);
+}
+
+/**
+ * Default recv_command implementation: reads the out-of-band command word.
+ **/
+static bool default_recv_command(const SOCKET socket, uint32_t *command)
+{
     bool result;
     uint32_t response;
-
-#ifndef _MSC_VER
-    if (m_use_transport_layer == SOCKET_TRANSPORT_TYPE_MCTP_LINUX_KERNEL) {
-        /*
-         * The Linux kernel MCTP socket carries no out-of-band command or
-         * transport-type framing.  Synthesise SOCKET_SPDM_COMMAND_NORMAL so
-         * the responder loop unconditionally dispatches each incoming message.
-         */
-        *command = SOCKET_SPDM_COMMAND_NORMAL;
-        return true;
-    }
-#endif
 
     result = read_data32(socket, &response);
     if (!result) {
@@ -233,14 +176,17 @@ bool receive_platform_command(const SOCKET socket, uint32_t *command)
 bool receive_platform_transport_type(const SOCKET socket,
                                      uint32_t *transport_type)
 {
-    bool result;
+    return g_io_ops->recv_transport_type(socket, transport_type);
+}
 
-#ifndef _MSC_VER
-    if (m_use_transport_layer == SOCKET_TRANSPORT_TYPE_MCTP_LINUX_KERNEL) {
-        *transport_type = SOCKET_TRANSPORT_TYPE_MCTP_LINUX_KERNEL;
-        return true;
-    }
-#endif
+/**
+ * Default recv_transport_type implementation: reads the out-of-band
+ * transport-type word.
+ **/
+static bool default_recv_transport_type(const SOCKET socket,
+                                        uint32_t *transport_type)
+{
+    bool result;
 
     result = read_data32(socket, transport_type);
     if (!result) {
@@ -341,70 +287,6 @@ bool write_bytes(const SOCKET socket, const uint8_t *buffer,
     uint32_t number_sent;
 
     number_sent = 0;
-#ifndef _MSC_VER
-    if (m_use_transport_layer == SOCKET_TRANSPORT_TYPE_MCTP_LINUX_KERNEL) {
-        /*
-         * Capture the role (responder vs. requester) once before the send
-         * loop.  Evaluating m_mctp_recv_addr_valid inside the loop would
-         * produce inconsistent addresses across iterations if the flag were
-         * cleared mid-loop.
-         */
-        bool is_responder_reply = (m_mctp_recv_addr_valid &&
-                                   (m_mctp_recv_addr.smctp_tag & MCTP_TAG_OWNER));
-        struct sockaddr_mctp addr = { 0 };
-        addr.smctp_family = AF_MCTP;
-        addr.smctp_type = MCTP_MESSAGE_TYPE_SPDM;
-
-        if (is_responder_reply) {
-            /*
-             * The last received message carried MCTP_TAG_OWNER, meaning
-             * the remote peer owns the tag.  We are the responder; reply
-             * to the requester using the same network, EID, and tag value
-             * but with MCTP_TAG_OWNER cleared (DSP0236 §8.17).
-             */
-            addr.smctp_network = m_mctp_recv_addr.smctp_network;
-            addr.smctp_addr.s_addr = m_mctp_recv_addr.smctp_addr.s_addr;
-            addr.smctp_tag = m_mctp_recv_addr.smctp_tag & MCTP_TAG_MASK;
-        } else {
-            /*
-             * We are the requester initiating a new transaction.  Set
-             * MCTP_TAG_OWNER so the kernel allocates a tag and routes the
-             * response back to this socket (DSP0236 §8.17).
-             */
-            addr.smctp_network = m_use_net;
-            addr.smctp_addr.s_addr = m_use_eid;
-            addr.smctp_tag = MCTP_TAG_OWNER;
-        }
-
-        while (number_sent < number_of_bytes) {
-            result = sendto(socket, (char *)(buffer + number_sent),
-                            number_of_bytes - number_sent, 0,
-                            (struct sockaddr *)&addr, sizeof(addr));
-            if (result == -1) {
-                /*
-                 * Edge case: send failure.  Clear the valid flag so the
-                 * next write_bytes does not reuse a stale peer address.
-                 */
-                if (is_responder_reply)
-                    m_mctp_recv_addr_valid = false;
-                EMU_ERR("Send error - 0x%x\n", socket_errno());
-                return false;
-            }
-            number_sent += result;
-        }
-
-        /*
-         * Edge case: reply sent successfully.  The MCTP message tag is now
-         * consumed by the kernel.  Reset the valid flag so write_bytes
-         * cannot accidentally reuse this peer address before the next
-         * recvfrom() delivers a fresh request.
-         */
-        if (is_responder_reply)
-            m_mctp_recv_addr_valid = false;
-
-        return true;
-    }
-#endif
     while (number_sent < number_of_bytes) {
         result = send(socket, (char *)(buffer + number_sent),
                       number_of_bytes - number_sent, 0);
@@ -440,29 +322,6 @@ bool write_multiple_bytes(const SOCKET socket, const uint8_t *buffer,
 {
     bool result;
 
-#ifndef _MSC_VER
-    if (m_use_transport_layer == SOCKET_TRANSPORT_TYPE_MCTP_LINUX_KERNEL) {
-        /*
-         * The Linux kernel AF_MCTP socket carries no length prefix.
-         * buffer[0] is the IC+MessageType byte added by the MCTP transport
-         * layer; the kernel encodes the message type in sockaddr_mctp.smctp_type,
-         * so we skip it when handing the payload to the kernel.
-         * A 1-byte buffer (type byte only, empty SPDM body) results in a
-         * 0-byte sendto which is valid for session control messages.
-         */
-        if (bytes_to_send == 0) {
-            EMU_ERR("MCTP send: zero-length buffer\n");
-            return false;
-        }
-        EMU_LOG("Platform port Transmit buffer (MCTP kernel):\n    ");
-        dump_data(buffer, bytes_to_send);
-        EMU_LOG("\n");
-        /* Strip the leading IC+MessageType byte before passing to the kernel. */
-        result = write_bytes(socket, buffer + 1, bytes_to_send - 1);
-        return result;
-    }
-#endif
-
     result = write_data32(socket, bytes_to_send);
     if (!result) {
         return result;
@@ -483,33 +342,18 @@ bool write_multiple_bytes(const SOCKET socket, const uint8_t *buffer,
     return true;
 }
 
-bool send_platform_data(const SOCKET socket, uint32_t command,
-                        const uint8_t *send_buffer, size_t bytes_to_send)
+/**
+ * Default send_payload implementation: writes the out-of-band command and
+ * transport-type words followed by the length-prefixed payload.  Used by
+ * TCP, MCTP (TCP-emulated), and PCI_DOE transports.
+ **/
+static bool default_send_payload(const SOCKET socket, uint32_t command,
+                                 const uint8_t *buffer,
+                                 uint32_t bytes_to_send)
 {
     bool result;
     uint32_t request;
     uint32_t transport_type;
-
-#ifndef _MSC_VER
-    if (m_use_transport_layer == SOCKET_TRANSPORT_TYPE_MCTP_LINUX_KERNEL) {
-        /* No command/transport_type framing over the kernel MCTP socket. */
-        result = write_multiple_bytes(socket, send_buffer,
-                                      (uint32_t)bytes_to_send);
-        if (!result) {
-            return result;
-        }
-        if (command == SOCKET_SPDM_COMMAND_NORMAL) {
-            mctp_header_t mctp_header;
-            mctp_header.header_version = 0;
-            mctp_header.destination_id = m_use_eid;
-            mctp_header.source_id = 0;
-            mctp_header.message_tag = 0xC0;
-            append_pcap_packet_data(&mctp_header, sizeof(mctp_header),
-                                    send_buffer, bytes_to_send);
-        }
-        return true;
-    }
-#endif
 
     request = command;
     result = write_data32(socket, request);
@@ -530,8 +374,16 @@ bool send_platform_data(const SOCKET socket, uint32_t command,
     dump_data((uint8_t *)&transport_type, sizeof(uint32_t));
     EMU_LOG("\n");
 
-    result = write_multiple_bytes(socket, send_buffer,
-                                  (uint32_t)bytes_to_send);
+    return write_multiple_bytes(socket, buffer, bytes_to_send);
+}
+
+bool send_platform_data(const SOCKET socket, uint32_t command,
+                        const uint8_t *send_buffer, size_t bytes_to_send)
+{
+    bool result;
+
+    result = g_io_ops->send_payload(socket, command, send_buffer,
+                                    (uint32_t)bytes_to_send);
     if (!result) {
         return result;
     }
@@ -548,6 +400,20 @@ bool send_platform_data(const SOCKET socket, uint32_t command,
             mctp_header_t mctp_header;
             mctp_header.header_version = 0;
             mctp_header.destination_id = 0;
+            mctp_header.source_id = 0;
+            mctp_header.message_tag = 0xC0;
+            append_pcap_packet_data(&mctp_header,
+                                    sizeof(mctp_header),
+                                    send_buffer, bytes_to_send);
+        } else if (m_use_transport_layer == SOCKET_TRANSPORT_TYPE_MCTP_LINUX_KERNEL) {
+
+            /* Append mctp_header_t for PCAP, using the configured
+             * destination EID (the Linux kernel MCTP socket does not carry
+             * this framing itself - see send_payload). */
+
+            mctp_header_t mctp_header;
+            mctp_header.header_version = 0;
+            mctp_header.destination_id = m_use_eid;
             mctp_header.source_id = 0;
             mctp_header.message_tag = 0xC0;
             append_pcap_packet_data(&mctp_header,

--- a/spdm_emu/spdm_emu_common/command.c
+++ b/spdm_emu/spdm_emu_common/command.c
@@ -9,6 +9,11 @@
 /* hack to add MCTP header for PCAP*/
 #include "industry_standard/mctp.h"
 
+#ifndef _MSC_VER
+#include <linux/mctp.h>
+#include <errno.h>
+#endif
+
 uint32_t m_use_transport_layer = SOCKET_TRANSPORT_TYPE_MCTP;
 
 uint32_t m_use_tcp_role_inquiry = SOCKET_TCP_NO_ROLE_INQUIRY;
@@ -16,6 +21,20 @@ uint32_t m_use_tcp_role_inquiry = SOCKET_TCP_NO_ROLE_INQUIRY;
 bool m_send_receive_buffer_acquired = false;
 uint8_t m_send_receive_buffer[LIBSPDM_MAX_SENDER_RECEIVER_BUFFER_SIZE];
 size_t m_send_receive_buffer_size;
+
+#ifndef _MSC_VER
+/*
+ * Peer address captured by the last recvfrom() on an AF_MCTP socket.
+ *
+ * The responder reads this after receiving a request; the tag field retains
+ * MCTP_TAG_OWNER so write_bytes() can detect the direction and reply
+ * correctly (TO cleared).  The requester overwrites it with the responder's
+ * address on each response but re-builds the destination from m_use_eid /
+ * m_use_net on every new outgoing request (MCTP_TAG_OWNER set).
+ */
+static struct sockaddr_mctp m_mctp_recv_addr;
+static bool m_mctp_recv_addr_valid = false;
+#endif
 
 /**
  * Read number of bytes data in blocking mode.
@@ -31,10 +50,25 @@ bool read_bytes(const SOCKET socket, uint8_t *buffer,
 
     number_received = 0;
     while (number_received < number_of_bytes) {
-        result = recv(socket, (char *)(buffer + number_received),
-                      number_of_bytes - number_received, 0);
-        if (result == -1)
-        {
+#ifndef _MSC_VER
+        if (m_use_transport_layer == SOCKET_TRANSPORT_TYPE_MCTP_LINUX_KERNEL) {
+            struct sockaddr_mctp addr;
+            socklen_t addrlen = sizeof(addr);
+            result = recvfrom(socket, (char *)(buffer + number_received),
+                              number_of_bytes - number_received, 0,
+                              (struct sockaddr *)&addr, &addrlen);
+            if (result > 0) {
+                m_mctp_recv_addr = addr;
+                m_mctp_recv_addr_valid = true;
+            }
+        } else {
+#endif
+            result = recv(socket, (char *)(buffer + number_received),
+                          number_of_bytes - number_received, 0);
+#ifndef _MSC_VER
+        }
+#endif
+        if (result == -1) {
             EMU_ERR("Receive error - 0x%x\n", socket_errno());
             return false;
         }
@@ -74,6 +108,46 @@ bool read_multiple_bytes(const SOCKET socket, uint8_t *buffer,
     uint32_t length;
     bool result;
 
+#ifndef _MSC_VER
+    if (m_use_transport_layer == SOCKET_TRANSPORT_TYPE_MCTP_LINUX_KERNEL) {
+        /*
+         * The Linux kernel AF_MCTP socket delivers one complete MCTP message
+         * per recvfrom() call.  The message type byte is carried in
+         * sockaddr_mctp.smctp_type by the kernel and is NOT present in the
+         * payload.  libspdm's MCTP transport layer, however, expects buffer[0]
+         * to be the IC+MessageType byte (0x05 for SPDM).  We therefore receive
+         * into buffer+1 and prepend the type byte ourselves.
+         */
+        struct sockaddr_mctp addr;
+        socklen_t addrlen = sizeof(addr);
+        int32_t rc;
+
+        if (max_buffer_length < 2) {
+            EMU_ERR("buffer too small for MCTP receive\n");
+            return false;
+        }
+
+        rc = recvfrom(socket, (char *)(buffer + 1), max_buffer_length - 1, 0,
+                      (struct sockaddr *)&addr, &addrlen);
+        if (rc < 0) {
+            EMU_ERR("MCTP recvfrom error: %s\n", strerror(errno));
+            return false;
+        }
+
+        m_mctp_recv_addr = addr;
+        m_mctp_recv_addr_valid = true;
+
+        /* Prepend the message type byte expected by the MCTP transport layer. */
+        buffer[0] = MCTP_MESSAGE_TYPE_SPDM;
+        *bytes_received = (uint32_t)rc + 1;
+
+        EMU_LOG("Platform port Receive buffer (MCTP kernel):\n    ");
+        dump_data(buffer, *bytes_received);
+        EMU_LOG("\n");
+        return true;
+    }
+#endif
+
     result = read_data32(socket, &length);
     if (!result) {
         return result;
@@ -109,6 +183,18 @@ bool receive_platform_command(const SOCKET socket, uint32_t *command)
     bool result;
     uint32_t response;
 
+#ifndef _MSC_VER
+    if (m_use_transport_layer == SOCKET_TRANSPORT_TYPE_MCTP_LINUX_KERNEL) {
+        /*
+         * The Linux kernel MCTP socket carries no out-of-band command or
+         * transport-type framing.  Synthesise SOCKET_SPDM_COMMAND_NORMAL so
+         * the responder loop unconditionally dispatches each incoming message.
+         */
+        *command = SOCKET_SPDM_COMMAND_NORMAL;
+        return true;
+    }
+#endif
+
     result = read_data32(socket, &response);
     if (!result) {
         return result;
@@ -126,6 +212,13 @@ bool receive_platform_transport_type(const SOCKET socket,
                                      uint32_t *transport_type)
 {
     bool result;
+
+#ifndef _MSC_VER
+    if (m_use_transport_layer == SOCKET_TRANSPORT_TYPE_MCTP_LINUX_KERNEL) {
+        *transport_type = SOCKET_TRANSPORT_TYPE_MCTP_LINUX_KERNEL;
+        return true;
+    }
+#endif
 
     result = read_data32(socket, transport_type);
     if (!result) {
@@ -227,8 +320,44 @@ bool write_bytes(const SOCKET socket, const uint8_t *buffer,
 
     number_sent = 0;
     while (number_sent < number_of_bytes) {
-        result = send(socket, (char *)(buffer + number_sent),
-                      number_of_bytes - number_sent, 0);
+#ifndef _MSC_VER
+        if (m_use_transport_layer == SOCKET_TRANSPORT_TYPE_MCTP_LINUX_KERNEL) {
+            struct sockaddr_mctp addr = { 0 };
+            addr.smctp_family = AF_MCTP;
+            addr.smctp_type = MCTP_MESSAGE_TYPE_SPDM;
+
+            if (m_mctp_recv_addr_valid &&
+                (m_mctp_recv_addr.smctp_tag & MCTP_TAG_OWNER)) {
+                /*
+                 * The last received message carried MCTP_TAG_OWNER, meaning
+                 * the remote peer owns the tag.  We are the responder; reply
+                 * to the requester using the same network, EID, and tag value
+                 * but with MCTP_TAG_OWNER cleared (DSP0236 §8.17).
+                 */
+                addr.smctp_network = m_mctp_recv_addr.smctp_network;
+                addr.smctp_addr.s_addr = m_mctp_recv_addr.smctp_addr.s_addr;
+                addr.smctp_tag = m_mctp_recv_addr.smctp_tag & MCTP_TAG_MASK;
+            } else {
+                /*
+                 * We are the requester initiating a new transaction.  Set
+                 * MCTP_TAG_OWNER so the kernel allocates a tag and routes the
+                 * response back to this socket (DSP0236 §8.17).
+                 */
+                addr.smctp_network = m_use_net;
+                addr.smctp_addr.s_addr = m_use_eid;
+                addr.smctp_tag = MCTP_TAG_OWNER;
+            }
+
+            result = sendto(socket, (char *)(buffer + number_sent),
+                            number_of_bytes - number_sent, 0,
+                            (struct sockaddr *)&addr, sizeof(addr));
+        } else {
+#endif
+            result = send(socket, (char *)(buffer + number_sent),
+                          number_of_bytes - number_sent, 0);
+#ifndef _MSC_VER
+        }
+#endif
         if (result == -1) {
 #ifdef _WIN32
             if (WSAGetLastError() == 0x2745) {
@@ -261,6 +390,29 @@ bool write_multiple_bytes(const SOCKET socket, const uint8_t *buffer,
 {
     bool result;
 
+#ifndef _MSC_VER
+    if (m_use_transport_layer == SOCKET_TRANSPORT_TYPE_MCTP_LINUX_KERNEL) {
+        /*
+         * The Linux kernel AF_MCTP socket carries no length prefix.
+         * buffer[0] is the IC+MessageType byte added by the MCTP transport
+         * layer; the kernel encodes the message type in sockaddr_mctp.smctp_type,
+         * so we skip it when handing the payload to the kernel.
+         * A 1-byte buffer (type byte only, empty SPDM body) results in a
+         * 0-byte sendto which is valid for session control messages.
+         */
+        if (bytes_to_send == 0) {
+            EMU_ERR("MCTP send: zero-length buffer\n");
+            return false;
+        }
+        EMU_LOG("Platform port Transmit buffer (MCTP kernel):\n    ");
+        dump_data(buffer, bytes_to_send);
+        EMU_LOG("\n");
+        /* Strip the leading IC+MessageType byte before passing to the kernel. */
+        result = write_bytes(socket, buffer + 1, bytes_to_send - 1);
+        return result;
+    }
+#endif
+
     result = write_data32(socket, bytes_to_send);
     if (!result) {
         return result;
@@ -287,6 +439,27 @@ bool send_platform_data(const SOCKET socket, uint32_t command,
     bool result;
     uint32_t request;
     uint32_t transport_type;
+
+#ifndef _MSC_VER
+    if (m_use_transport_layer == SOCKET_TRANSPORT_TYPE_MCTP_LINUX_KERNEL) {
+        /* No command/transport_type framing over the kernel MCTP socket. */
+        result = write_multiple_bytes(socket, send_buffer,
+                                      (uint32_t)bytes_to_send);
+        if (!result) {
+            return result;
+        }
+        if (command == SOCKET_SPDM_COMMAND_NORMAL) {
+            mctp_header_t mctp_header;
+            mctp_header.header_version = 0;
+            mctp_header.destination_id = m_use_eid;
+            mctp_header.source_id = 0;
+            mctp_header.message_tag = 0xC0;
+            append_pcap_packet_data(&mctp_header, sizeof(mctp_header),
+                                    send_buffer, bytes_to_send);
+        }
+        return true;
+    }
+#endif
 
     request = command;
     result = write_data32(socket, request);

--- a/spdm_emu/spdm_emu_common/command.h
+++ b/spdm_emu/spdm_emu_common/command.h
@@ -30,6 +30,13 @@
 #define SOCKET_TRANSPORT_TYPE_MCTP 0x01
 #define SOCKET_TRANSPORT_TYPE_PCI_DOE 0x02
 #define SOCKET_TRANSPORT_TYPE_TCP 0x03
+#ifndef _MSC_VER
+/* Linux kernel AF_MCTP socket transport (not available on Windows) */
+#define SOCKET_TRANSPORT_TYPE_MCTP_LINUX_KERNEL 0x04
+
+/* MCTP message type for SPDM (DMTF DSP0239) */
+#define MCTP_MESSAGE_TYPE_SPDM 0x05
+#endif
 
 #define SOCKET_TCP_NO_ROLE_INQUIRY 0x00
 #define SOCKET_TCP_ROLE_INQUIRY 0x01

--- a/spdm_emu/spdm_emu_common/command.h
+++ b/spdm_emu/spdm_emu_common/command.h
@@ -30,12 +30,17 @@
 #define SOCKET_TRANSPORT_TYPE_MCTP 0x01
 #define SOCKET_TRANSPORT_TYPE_PCI_DOE 0x02
 #define SOCKET_TRANSPORT_TYPE_TCP 0x03
-#ifndef _MSC_VER
-/* Linux kernel AF_MCTP socket transport (not available on Windows) */
+/* Linux kernel AF_MCTP socket transport.
+ * Selecting this transport on non-Linux platforms is rejected at runtime. */
 #define SOCKET_TRANSPORT_TYPE_MCTP_LINUX_KERNEL 0x04
 
+#ifndef _MSC_VER
 /* MCTP message type for SPDM (DMTF DSP0239) */
 #define MCTP_MESSAGE_TYPE_SPDM 0x05
+/* Fallback when linux/mctp.h is not available - value is never used on Windows
+ * because the transport is rejected at runtime before any MCTP socket call. */
+#else
+#define MCTP_NET_ANY 0
 #endif
 
 #define SOCKET_TCP_NO_ROLE_INQUIRY 0x00

--- a/spdm_emu/spdm_emu_common/command.h
+++ b/spdm_emu/spdm_emu_common/command.h
@@ -1,6 +1,6 @@
 /**
  *  Copyright Notice:
- *  Copyright 2021-2025 DMTF. All rights reserved.
+ *  Copyright 2021-2026 DMTF. All rights reserved.
  *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/spdm-emu/blob/main/LICENSE.md
  **/
 
@@ -34,14 +34,40 @@
  * Selecting this transport on non-Linux platforms is rejected at runtime. */
 #define SOCKET_TRANSPORT_TYPE_MCTP_LINUX_KERNEL 0x04
 
-#ifndef _MSC_VER
 /* MCTP message type for SPDM (DMTF DSP0239) */
 #define MCTP_MESSAGE_TYPE_SPDM 0x05
-/* Fallback when linux/mctp.h is not available - value is never used on Windows
- * because the transport is rejected at runtime before any MCTP socket call. */
-#else
+/* MCTP "any network" identifier (DSP0236 Table 14). Also defined by
+ * <linux/mctp.h> as 0 on Linux; defining it here lets non-MCTP-kernel code
+ * (e.g. default --net value) reference it without pulling in kernel headers. */
 #define MCTP_NET_ANY 0
-#endif
+
+/**
+ * Platform IO abstraction (strategy / vtable pattern).
+ *
+ * command.c selects the right implementation at startup based on the chosen
+ * transport.  Adding a new transport only requires providing a new ops struct
+ * and registering it — command.c itself needs no changes.
+ *
+ * recv_command:        Read (or synthesise) the out-of-band SPDM command word.
+ * recv_transport_type: Read (or synthesise) the transport-type word.
+ * recv_payload:        Read a complete SPDM payload into buf.
+ * send_payload:        Send a complete SPDM payload (command is PCAP-only).
+ */
+typedef struct {
+    bool (*recv_command)(SOCKET socket, uint32_t *command);
+    bool (*recv_transport_type)(SOCKET socket, uint32_t *transport_type);
+    bool (*recv_payload)(SOCKET socket, uint8_t *buf,
+                         uint32_t *bytes_received, uint32_t max_bytes);
+    bool (*send_payload)(SOCKET socket, uint32_t command,
+                         const uint8_t *buf, uint32_t bytes_to_send);
+} spdm_emu_io_ops_t;
+
+/**
+ * Register the active IO ops.  Call once per socket lifetime before the
+ * first send/receive operation.  Defaults to the socket (TCP/MCTP/PCI_DOE)
+ * implementation when not called.
+ */
+void spdm_emu_io_ops_register(const spdm_emu_io_ops_t *ops);
 
 #define SOCKET_TCP_NO_ROLE_INQUIRY 0x00
 #define SOCKET_TCP_ROLE_INQUIRY 0x01

--- a/spdm_emu/spdm_emu_common/spdm_emu.c
+++ b/spdm_emu/spdm_emu_common/spdm_emu.c
@@ -1770,6 +1770,12 @@ bool init_client(SOCKET *sock, uint16_t port)
             return false;
         }
 
+        /*
+         * Edge case: new socket; discard any peer address left over from a
+         * previous session so write_bytes starts in the requester state.
+         */
+        mctp_kernel_reset_peer_addr();
+
         printf("MCTP socket created (dst EID 0x%02x, net %u)\n",
                m_use_eid, m_use_net);
         *sock = client_socket;

--- a/spdm_emu/spdm_emu_common/spdm_emu.c
+++ b/spdm_emu/spdm_emu_common/spdm_emu.c
@@ -1,15 +1,10 @@
 /**
  *  Copyright Notice:
- *  Copyright 2021-2025 DMTF. All rights reserved.
+ *  Copyright 2021-2026 DMTF. All rights reserved.
  *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/spdm-emu/blob/main/LICENSE.md
  **/
 
 #include "spdm_emu.h"
-
-#ifndef _MSC_VER
-#include <linux/mctp.h>
-#include <errno.h>
-#endif
 
 /*
  * EXE_MODE_SHUTDOWN
@@ -1744,45 +1739,6 @@ bool init_client(SOCKET *sock, uint16_t port)
 {
     SOCKET client_socket;
 
-#ifndef _MSC_VER
-    if (m_use_transport_layer == SOCKET_TRANSPORT_TYPE_MCTP_LINUX_KERNEL) {
-        /*
-         * Create an AF_MCTP datagram socket for the SPDM requester.
-         *
-         * The requester does NOT call bind().  When sendto() is issued with
-         * MCTP_TAG_OWNER the kernel allocates a message tag and records the
-         * (src_eid, dst_eid, tag) tuple so that the corresponding response is
-         * delivered back to this socket automatically.  Binding here would
-         * compete with a responder that has already bound the same
-         * (network, MCTP_ADDR_ANY, type) tuple and cause EADDRINUSE.
-         *
-         * m_use_eid must be a valid unicast EID (1-254, per DSP0236 §8.2).
-         */
-        if (m_use_eid == 0) {
-            printf("MCTP_KERNEL transport requires a destination EID. "
-                   "Use --eid <1-254>.\n");
-            return false;
-        }
-
-        client_socket = socket(AF_MCTP, SOCK_DGRAM, 0);
-        if (client_socket == INVALID_SOCKET) {
-            printf("Create MCTP socket failed - %d\n", errno);
-            return false;
-        }
-
-        /*
-         * Edge case: new socket; discard any peer address left over from a
-         * previous session so write_bytes starts in the requester state.
-         */
-        mctp_kernel_reset_peer_addr();
-
-        printf("MCTP socket created (dst EID 0x%02x, net %u)\n",
-               m_use_eid, m_use_net);
-        *sock = client_socket;
-        return true;
-    }
-#endif
-
     struct sockaddr_in server_addr;
     struct in_addr ip_addr;
     int32_t ret_val;
@@ -1839,53 +1795,6 @@ bool init_client(SOCKET *sock, uint16_t port)
     *sock = client_socket;
     return true;
 }
-
-#ifndef _MSC_VER
-/**
- * Create and bind an AF_MCTP datagram socket for the SPDM responder.
- *
- * The socket is bound to (m_use_net, MCTP_ADDR_ANY, MCTP_MESSAGE_TYPE_SPDM)
- * so it receives all incoming SPDM messages regardless of the local EID.
- * If m_use_net is MCTP_NET_ANY the kernel selects the network automatically.
- *
- * The port parameter is ignored (MCTP has no port concept); it is kept for
- * signature compatibility with create_socket().
- **/
-bool create_mctp_kernel_socket(uint16_t port_number, SOCKET *mctp_socket)
-{
-    (void)port_number;
-
-    SOCKET s = socket(AF_MCTP, SOCK_DGRAM, 0);
-    if (s == INVALID_SOCKET) {
-        printf("Create MCTP socket failed - %d\n", errno);
-        return false;
-    }
-
-    struct sockaddr_mctp addr = { 0 };
-    addr.smctp_family  = AF_MCTP;
-    addr.smctp_network = m_use_net;
-    /*
-     * Bind to MCTP_ADDR_ANY so the responder receives requests sent to any
-     * local EID.  Binding to a specific EID requires that EID to be assigned
-     * to a local interface by the MCTP daemon; using MCTP_ADDR_ANY avoids
-     * that prerequisite and is the common deployment pattern.
-     */
-    addr.smctp_addr.s_addr = MCTP_ADDR_ANY;
-    addr.smctp_type = MCTP_MESSAGE_TYPE_SPDM;
-
-    int rc = bind(s, (struct sockaddr *)&addr, sizeof(addr));
-    if (rc == -1) {
-        printf("MCTP bind failed - %s\n", strerror(errno));
-        closesocket(s);
-        return false;
-    }
-
-    printf("MCTP responder socket bound (net %u, type 0x%02x)\n",
-           m_use_net, MCTP_MESSAGE_TYPE_SPDM);
-    *mctp_socket = s;
-    return true;
-}
-#endif
 
 bool create_socket(uint16_t port_number, SOCKET *listen_socket)
 {

--- a/spdm_emu/spdm_emu_common/spdm_emu.c
+++ b/spdm_emu/spdm_emu_common/spdm_emu.c
@@ -49,12 +49,12 @@ struct in_addr m_ip_address = { { { 127, 0, 0, 1 } } };
 struct in_addr m_ip_address = { 0x0100007F };
 #endif
 
-#ifndef _MSC_VER
 /*
  * MCTP Endpoint ID of the remote peer (requester: destination; responder: own
  * EID to bind to, or 0 / MCTP_ADDR_ANY for any).  EID 0x00 is the Null EID
  * (DSP0236 §8.2) and is not valid as a unicast destination address; the
  * requester must supply a valid EID via --eid.
+ * Parsed on all platforms; only used when MCTP_KERNEL transport is active.
  */
 uint8_t m_use_eid = 0;
 
@@ -63,24 +63,18 @@ uint8_t m_use_eid = 0;
  * the OS picks the correct network automatically when only one network is
  * present.  Use --net to target a specific network when multiple MCTP
  * networks are routed on the same host.
+ * Parsed on all platforms; only used when MCTP_KERNEL transport is active.
  */
 uint32_t m_use_net = MCTP_NET_ANY;
-#endif
 
 void print_usage(const char *name)
 {
-#ifndef _MSC_VER
     printf("\n%s [--trans MCTP|PCI_DOE|TCP|MCTP_KERNEL|NONE]\n", name);
-#else
-    printf("\n%s [--trans MCTP|PCI_DOE|TCP|NONE]\n", name);
-#endif
     printf("   [--tcp_sub RI|NO_RI]\n");
     printf("   [--ip <ip_address>]\n");
     printf("   [--port <port_number>]\n");
-#ifndef _MSC_VER
-    printf("   [--eid <endpoint_id>]  (MCTP_KERNEL: destination EID, 1-254)\n");
+    printf("   [--eid <endpoint_id>]  (MCTP_KERNEL: destination EID, 1~254)\n");
     printf("   [--net <network_id>]   (MCTP_KERNEL: MCTP network, default any)\n");
-#endif
     printf("   [--ver 1.0|1.1|1.2|1.3|1.4]\n");
     printf("   [--sec_ver 1.0|1.1|1.2]\n");
     printf("   [--decap_tdisp\n");
@@ -268,9 +262,7 @@ value_string_entry_t m_transport_value_string_table[] = {
     { SOCKET_TRANSPORT_TYPE_MCTP, "MCTP" },
     { SOCKET_TRANSPORT_TYPE_PCI_DOE, "PCI_DOE" },
     { SOCKET_TRANSPORT_TYPE_TCP, "TCP"},
-#ifndef _MSC_VER
     { SOCKET_TRANSPORT_TYPE_MCTP_LINUX_KERNEL, "MCTP_KERNEL" },
-#endif
 };
 
 value_string_entry_t m_tcp_subtype_string_table[] = {
@@ -763,6 +755,13 @@ void process_args(char *program_name, int argc, char *argv[])
                     exit(0);
                 }
                 printf("trans - 0x%x\n", m_use_transport_layer);
+#ifdef _MSC_VER
+                if (m_use_transport_layer ==
+                        SOCKET_TRANSPORT_TYPE_MCTP_LINUX_KERNEL) {
+                    printf("MCTP_KERNEL transport is only supported on Linux.\n");
+                    exit(0);
+                }
+#endif
                 argc -= 2;
                 argv += 2;
                 continue;
@@ -1665,7 +1664,6 @@ void process_args(char *program_name, int argc, char *argv[])
             continue;
         }
 
-#ifndef _MSC_VER
         if (strcmp(argv[0], "--eid") == 0) {
             if (argc >= 2) {
                 long val = strtol(argv[1], NULL, 0);
@@ -1711,7 +1709,6 @@ void process_args(char *program_name, int argc, char *argv[])
                 exit(0);
             }
         }
-#endif
 
         printf("invalid %s\n", argv[0]);
         print_usage(program_name);

--- a/spdm_emu/spdm_emu_common/spdm_emu.c
+++ b/spdm_emu/spdm_emu_common/spdm_emu.c
@@ -6,6 +6,11 @@
 
 #include "spdm_emu.h"
 
+#ifndef _MSC_VER
+#include <linux/mctp.h>
+#include <errno.h>
+#endif
+
 /*
  * EXE_MODE_SHUTDOWN
  * EXE_MODE_CONTINUE
@@ -44,12 +49,38 @@ struct in_addr m_ip_address = { { { 127, 0, 0, 1 } } };
 struct in_addr m_ip_address = { 0x0100007F };
 #endif
 
+#ifndef _MSC_VER
+/*
+ * MCTP Endpoint ID of the remote peer (requester: destination; responder: own
+ * EID to bind to, or 0 / MCTP_ADDR_ANY for any).  EID 0x00 is the Null EID
+ * (DSP0236 §8.2) and is not valid as a unicast destination address; the
+ * requester must supply a valid EID via --eid.
+ */
+uint8_t m_use_eid = 0;
+
+/*
+ * MCTP network identifier (DSP0236 §8.2).  Defaults to MCTP_NET_ANY so that
+ * the OS picks the correct network automatically when only one network is
+ * present.  Use --net to target a specific network when multiple MCTP
+ * networks are routed on the same host.
+ */
+uint32_t m_use_net = MCTP_NET_ANY;
+#endif
+
 void print_usage(const char *name)
 {
+#ifndef _MSC_VER
+    printf("\n%s [--trans MCTP|PCI_DOE|TCP|MCTP_KERNEL|NONE]\n", name);
+#else
     printf("\n%s [--trans MCTP|PCI_DOE|TCP|NONE]\n", name);
+#endif
     printf("   [--tcp_sub RI|NO_RI]\n");
     printf("   [--ip <ip_address>]\n");
     printf("   [--port <port_number>]\n");
+#ifndef _MSC_VER
+    printf("   [--eid <endpoint_id>]  (MCTP_KERNEL: destination EID, 1-254)\n");
+    printf("   [--net <network_id>]   (MCTP_KERNEL: MCTP network, default any)\n");
+#endif
     printf("   [--ver 1.0|1.1|1.2|1.3|1.4]\n");
     printf("   [--sec_ver 1.0|1.1|1.2]\n");
     printf("   [--decap_tdisp\n");
@@ -236,7 +267,10 @@ value_string_entry_t m_transport_value_string_table[] = {
     { SOCKET_TRANSPORT_TYPE_NONE, "NONE"},
     { SOCKET_TRANSPORT_TYPE_MCTP, "MCTP" },
     { SOCKET_TRANSPORT_TYPE_PCI_DOE, "PCI_DOE" },
-    { SOCKET_TRANSPORT_TYPE_TCP, "TCP"}
+    { SOCKET_TRANSPORT_TYPE_TCP, "TCP"},
+#ifndef _MSC_VER
+    { SOCKET_TRANSPORT_TYPE_MCTP_LINUX_KERNEL, "MCTP_KERNEL" },
+#endif
 };
 
 value_string_entry_t m_tcp_subtype_string_table[] = {
@@ -1631,6 +1665,54 @@ void process_args(char *program_name, int argc, char *argv[])
             continue;
         }
 
+#ifndef _MSC_VER
+        if (strcmp(argv[0], "--eid") == 0) {
+            if (argc >= 2) {
+                long val = strtol(argv[1], NULL, 0);
+                /*
+                 * EID 0x00 is the Null EID (DSP0236 §8.2) - not usable as a
+                 * unicast destination.  EID 0xFF is the broadcast EID.
+                 * Valid unicast EIDs are 0x01..0xFE.
+                 */
+                if (val < 0x01 || val > 0xFE) {
+                    printf("invalid --eid %s (valid unicast range: 1-254)\n",
+                           argv[1]);
+                    print_usage(program_name);
+                    exit(0);
+                }
+                m_use_eid = (uint8_t)val;
+                printf("eid - 0x%02x\n", m_use_eid);
+                argc -= 2;
+                argv += 2;
+                continue;
+            } else {
+                printf("invalid --eid\n");
+                print_usage(program_name);
+                exit(0);
+            }
+        }
+
+        if (strcmp(argv[0], "--net") == 0) {
+            if (argc >= 2) {
+                long val = strtol(argv[1], NULL, 0);
+                if (val < 0) {
+                    printf("invalid --net %s\n", argv[1]);
+                    print_usage(program_name);
+                    exit(0);
+                }
+                m_use_net = (uint32_t)val;
+                printf("net - %u\n", m_use_net);
+                argc -= 2;
+                argv += 2;
+                continue;
+            } else {
+                printf("invalid --net\n");
+                print_usage(program_name);
+                exit(0);
+            }
+        }
+#endif
+
         printf("invalid %s\n", argv[0]);
         print_usage(program_name);
         exit(0);
@@ -1664,6 +1746,40 @@ bool convert_ip_to_addr(const char *ip_string, struct in_addr *addr)
 bool init_client(SOCKET *sock, uint16_t port)
 {
     SOCKET client_socket;
+
+#ifndef _MSC_VER
+    if (m_use_transport_layer == SOCKET_TRANSPORT_TYPE_MCTP_LINUX_KERNEL) {
+        /*
+         * Create an AF_MCTP datagram socket for the SPDM requester.
+         *
+         * The requester does NOT call bind().  When sendto() is issued with
+         * MCTP_TAG_OWNER the kernel allocates a message tag and records the
+         * (src_eid, dst_eid, tag) tuple so that the corresponding response is
+         * delivered back to this socket automatically.  Binding here would
+         * compete with a responder that has already bound the same
+         * (network, MCTP_ADDR_ANY, type) tuple and cause EADDRINUSE.
+         *
+         * m_use_eid must be a valid unicast EID (1-254, per DSP0236 §8.2).
+         */
+        if (m_use_eid == 0) {
+            printf("MCTP_KERNEL transport requires a destination EID. "
+                   "Use --eid <1-254>.\n");
+            return false;
+        }
+
+        client_socket = socket(AF_MCTP, SOCK_DGRAM, 0);
+        if (client_socket == INVALID_SOCKET) {
+            printf("Create MCTP socket failed - %d\n", errno);
+            return false;
+        }
+
+        printf("MCTP socket created (dst EID 0x%02x, net %u)\n",
+               m_use_eid, m_use_net);
+        *sock = client_socket;
+        return true;
+    }
+#endif
+
     struct sockaddr_in server_addr;
     struct in_addr ip_addr;
     int32_t ret_val;
@@ -1720,6 +1836,53 @@ bool init_client(SOCKET *sock, uint16_t port)
     *sock = client_socket;
     return true;
 }
+
+#ifndef _MSC_VER
+/**
+ * Create and bind an AF_MCTP datagram socket for the SPDM responder.
+ *
+ * The socket is bound to (m_use_net, MCTP_ADDR_ANY, MCTP_MESSAGE_TYPE_SPDM)
+ * so it receives all incoming SPDM messages regardless of the local EID.
+ * If m_use_net is MCTP_NET_ANY the kernel selects the network automatically.
+ *
+ * The port parameter is ignored (MCTP has no port concept); it is kept for
+ * signature compatibility with create_socket().
+ **/
+bool create_mctp_kernel_socket(uint16_t port_number, SOCKET *mctp_socket)
+{
+    (void)port_number;
+
+    SOCKET s = socket(AF_MCTP, SOCK_DGRAM, 0);
+    if (s == INVALID_SOCKET) {
+        printf("Create MCTP socket failed - %d\n", errno);
+        return false;
+    }
+
+    struct sockaddr_mctp addr = { 0 };
+    addr.smctp_family  = AF_MCTP;
+    addr.smctp_network = m_use_net;
+    /*
+     * Bind to MCTP_ADDR_ANY so the responder receives requests sent to any
+     * local EID.  Binding to a specific EID requires that EID to be assigned
+     * to a local interface by the MCTP daemon; using MCTP_ADDR_ANY avoids
+     * that prerequisite and is the common deployment pattern.
+     */
+    addr.smctp_addr.s_addr = MCTP_ADDR_ANY;
+    addr.smctp_type = MCTP_MESSAGE_TYPE_SPDM;
+
+    int rc = bind(s, (struct sockaddr *)&addr, sizeof(addr));
+    if (rc == -1) {
+        printf("MCTP bind failed - %s\n", strerror(errno));
+        closesocket(s);
+        return false;
+    }
+
+    printf("MCTP responder socket bound (net %u, type 0x%02x)\n",
+           m_use_net, MCTP_MESSAGE_TYPE_SPDM);
+    *mctp_socket = s;
+    return true;
+}
+#endif
 
 bool create_socket(uint16_t port_number, SOCKET *listen_socket)
 {

--- a/spdm_emu/spdm_emu_common/spdm_emu.h
+++ b/spdm_emu/spdm_emu_common/spdm_emu.h
@@ -27,11 +27,10 @@ extern uint32_t m_use_tcp_role_inquiry;
 extern char m_ip_address_string[16];
 extern uint16_t m_custom_port;
 extern bool m_ip_explicitly_set;
-#ifndef _MSC_VER
-/* MCTP kernel transport: destination/bind EID and network (Linux only) */
+/* MCTP kernel transport: destination/bind EID and network.
+ * Parsed on all platforms; effective only on Linux with MCTP_KERNEL transport. */
 extern uint8_t m_use_eid;
 extern uint32_t m_use_net;
-#endif
 extern uint8_t m_use_version;
 extern uint8_t m_use_secured_message_version;
 extern bool m_decap_tdisp;

--- a/spdm_emu/spdm_emu_common/spdm_emu.h
+++ b/spdm_emu/spdm_emu_common/spdm_emu.h
@@ -27,6 +27,11 @@ extern uint32_t m_use_tcp_role_inquiry;
 extern char m_ip_address_string[16];
 extern uint16_t m_custom_port;
 extern bool m_ip_explicitly_set;
+#ifndef _MSC_VER
+/* MCTP kernel transport: destination/bind EID and network (Linux only) */
+extern uint8_t m_use_eid;
+extern uint32_t m_use_net;
+#endif
 extern uint8_t m_use_version;
 extern uint8_t m_use_secured_message_version;
 extern bool m_decap_tdisp;
@@ -182,6 +187,10 @@ void process_args(char *program_name, int argc, char *argv[]);
 void dump_supported_algorithms(const void *buffer, size_t buffer_size);
 
 bool create_socket(uint16_t port_number, SOCKET *listen_socket);
+
+#ifndef _MSC_VER
+bool create_mctp_kernel_socket(uint16_t port_number, SOCKET *mctp_socket);
+#endif
 
 bool init_client(SOCKET *sock, uint16_t port);
 

--- a/spdm_emu/spdm_emu_common/spdm_emu.h
+++ b/spdm_emu/spdm_emu_common/spdm_emu.h
@@ -1,6 +1,6 @@
 /**
  *  Copyright Notice:
- *  Copyright 2021-2025 DMTF. All rights reserved.
+ *  Copyright 2021-2026 DMTF. All rights reserved.
  *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/spdm-emu/blob/main/LICENSE.md
  **/
 
@@ -186,12 +186,6 @@ void process_args(char *program_name, int argc, char *argv[]);
 void dump_supported_algorithms(const void *buffer, size_t buffer_size);
 
 bool create_socket(uint16_t port_number, SOCKET *listen_socket);
-
-#ifndef _MSC_VER
-bool create_mctp_kernel_socket(uint16_t port_number, SOCKET *mctp_socket);
-/* Reset stored MCTP peer address; call when opening a new MCTP socket. */
-void mctp_kernel_reset_peer_addr(void);
-#endif
 
 bool init_client(SOCKET *sock, uint16_t port);
 

--- a/spdm_emu/spdm_emu_common/spdm_emu.h
+++ b/spdm_emu/spdm_emu_common/spdm_emu.h
@@ -189,6 +189,8 @@ bool create_socket(uint16_t port_number, SOCKET *listen_socket);
 
 #ifndef _MSC_VER
 bool create_mctp_kernel_socket(uint16_t port_number, SOCKET *mctp_socket);
+/* Reset stored MCTP peer address; call when opening a new MCTP socket. */
+void mctp_kernel_reset_peer_addr(void);
 #endif
 
 bool init_client(SOCKET *sock, uint16_t port);

--- a/spdm_emu/spdm_emu_common/spdm_emu_mctp_kernel.c
+++ b/spdm_emu/spdm_emu_common/spdm_emu_mctp_kernel.c
@@ -1,0 +1,207 @@
+/**
+ *  Copyright Notice:
+ *  Copyright 2021-2026 DMTF. All rights reserved.
+ *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/spdm-emu/blob/main/LICENSE.md
+ **/
+
+/**
+ * Linux kernel AF_MCTP socket IO implementation.
+ *
+ * This file is only compiled on Linux (CMake if(UNIX)).  It contains no
+ * compile-time platform guards — the CMake condition is the guard.
+ *
+ * It registers a spdm_emu_io_ops_t vtable (mctp_kernel_io_ops) into
+ * command.c's dispatch table.  The vtable replaces the send/recv/framing
+ * logic that would otherwise be scattered through command.c as
+ * #ifndef _MSC_VER / MCTP_LINUX_KERNEL branches.
+ **/
+
+#include "spdm_emu.h"
+#include "spdm_emu_mctp_kernel.h"
+
+#include <linux/mctp.h>
+#include <errno.h>
+#include <string.h>
+
+/*
+ * Peer address captured by the most-recent recvfrom() call.
+ *
+ * DSP0236 §8.17: a requester sets MCTP_TAG_OWNER in outgoing messages and
+ * the kernel allocates a tag, routing the response back to the same socket.
+ * A responder receives MCTP_TAG_OWNER=1 and must reply with the same tag
+ * value but MCTP_TAG_OWNER=0.  We detect which role we are from whether the
+ * last received message carried MCTP_TAG_OWNER.
+ */
+static struct sockaddr_mctp m_mctp_recv_addr;
+static bool m_mctp_recv_addr_valid = false;
+
+/* ── Receive operations ──────────────────────────────────────────────────── */
+
+static bool mctp_kernel_recv_command(SOCKET socket, uint32_t *command)
+{
+    (void)socket;
+    /*
+     * The Linux kernel MCTP socket carries no out-of-band command framing.
+     * Synthesise SOCKET_SPDM_COMMAND_NORMAL so the responder dispatch loop
+     * processes each incoming datagram as a normal SPDM message.
+     */
+    *command = SOCKET_SPDM_COMMAND_NORMAL;
+    return true;
+}
+
+static bool mctp_kernel_recv_transport_type(SOCKET socket,
+                                             uint32_t *transport_type)
+{
+    (void)socket;
+    *transport_type = SOCKET_TRANSPORT_TYPE_MCTP_LINUX_KERNEL;
+    return true;
+}
+
+static bool mctp_kernel_recv_payload(SOCKET socket, uint8_t *buffer,
+                                      uint32_t *bytes_received,
+                                      uint32_t max_buffer_length)
+{
+    struct sockaddr_mctp addr;
+    socklen_t addrlen = sizeof(addr);
+    int32_t rc;
+
+    if (max_buffer_length < 2) {
+        EMU_ERR("MCTP recv: buffer too small\n");
+        return false;
+    }
+
+    /*
+     * The kernel delivers one complete MCTP message per recvfrom() and does
+     * NOT include the message type byte in the payload (it is carried in
+     * sockaddr_mctp.smctp_type).  libspdm's MCTP transport layer expects
+     * buffer[0] to be the IC+MessageType byte (0x05 for SPDM), so we
+     * receive into buffer+1 and prepend it ourselves.
+     */
+    rc = recvfrom(socket, (char *)(buffer + 1), max_buffer_length - 1, 0,
+                  (struct sockaddr *)&addr, &addrlen);
+    if (rc < 0) {
+        m_mctp_recv_addr_valid = false;
+        EMU_ERR("MCTP recvfrom error: %s\n", strerror(errno));
+        return false;
+    }
+    if (rc == 0) {
+        /* Edge case: empty datagram — peer address is not meaningful. */
+        m_mctp_recv_addr_valid = false;
+        EMU_ERR("MCTP recvfrom: empty datagram\n");
+        return false;
+    }
+
+    m_mctp_recv_addr       = addr;
+    m_mctp_recv_addr_valid = true;
+
+    buffer[0]      = MCTP_MESSAGE_TYPE_SPDM;
+    *bytes_received = (uint32_t)rc + 1;
+
+    EMU_LOG("Platform port Receive buffer (MCTP kernel):\n    ");
+    dump_data(buffer, *bytes_received);
+    EMU_LOG("\n");
+    return true;
+}
+
+/* ── Send operations ─────────────────────────────────────────────────────── */
+
+static bool mctp_kernel_send_payload(SOCKET socket, uint32_t command,
+                                      const uint8_t *buffer,
+                                      uint32_t bytes_to_send)
+{
+    (void)command;
+
+    if (bytes_to_send == 0) {
+        EMU_ERR("MCTP send: zero-length buffer\n");
+        return false;
+    }
+
+    /*
+     * Capture the role once before the send loop so all iterations use the
+     * same peer address.  Evaluating m_mctp_recv_addr_valid inside the loop
+     * could give inconsistent results if the flag is cleared mid-loop.
+     */
+    bool is_responder_reply = (m_mctp_recv_addr_valid &&
+                               (m_mctp_recv_addr.smctp_tag & MCTP_TAG_OWNER));
+
+    struct sockaddr_mctp addr = { 0 };
+    addr.smctp_family = AF_MCTP;
+    addr.smctp_type   = MCTP_MESSAGE_TYPE_SPDM;
+
+    if (is_responder_reply) {
+        /*
+         * Reply to a request: clear MCTP_TAG_OWNER, keep the same network,
+         * source EID, and tag value (DSP0236 §8.17).
+         */
+        addr.smctp_network      = m_mctp_recv_addr.smctp_network;
+        addr.smctp_addr.s_addr  = m_mctp_recv_addr.smctp_addr.s_addr;
+        addr.smctp_tag          = m_mctp_recv_addr.smctp_tag & MCTP_TAG_MASK;
+    } else {
+        /*
+         * New request from the requester: set MCTP_TAG_OWNER so the kernel
+         * allocates a tag and routes the response back to this socket.
+         */
+        addr.smctp_network      = m_use_net;
+        addr.smctp_addr.s_addr  = m_use_eid;
+        addr.smctp_tag          = MCTP_TAG_OWNER;
+    }
+
+    /*
+     * buffer[0] is the IC+MessageType byte added by the libspdm MCTP
+     * transport layer.  The kernel takes the type from smctp_type, so we
+     * strip it before handing the payload to the kernel.  A 1-byte buffer
+     * (type byte only, empty SPDM body) yields a 0-byte sendto, which is
+     * valid for session control messages.
+     */
+    EMU_LOG("Platform port Transmit buffer (MCTP kernel):\n    ");
+    dump_data(buffer, bytes_to_send);
+    EMU_LOG("\n");
+
+    const uint8_t *payload     = buffer + 1;
+    uint32_t       payload_len = bytes_to_send - 1;
+    uint32_t       number_sent = 0;
+
+    while (number_sent < payload_len) {
+        int32_t result = sendto(socket,
+                                (const char *)(payload + number_sent),
+                                payload_len - number_sent, 0,
+                                (const struct sockaddr *)&addr, sizeof(addr));
+        if (result == -1) {
+            /* Edge case: send failure — invalidate stale peer address. */
+            if (is_responder_reply)
+                m_mctp_recv_addr_valid = false;
+            EMU_ERR("MCTP sendto error - 0x%x\n", socket_errno());
+            return false;
+        }
+        number_sent += (uint32_t)result;
+    }
+
+    /*
+     * Edge case: reply sent successfully.  The MCTP tag is now consumed by
+     * the kernel; reset the flag so the next send does not reuse this peer
+     * address before a fresh recvfrom() delivers the next request.
+     */
+    if (is_responder_reply)
+        m_mctp_recv_addr_valid = false;
+
+    return true;
+}
+
+/* ── Vtable and registration ─────────────────────────────────────────────── */
+
+static const spdm_emu_io_ops_t mctp_kernel_io_ops = {
+    mctp_kernel_recv_command,
+    mctp_kernel_recv_transport_type,
+    mctp_kernel_recv_payload,
+    mctp_kernel_send_payload,
+};
+
+void spdm_emu_mctp_kernel_register_io_ops(void)
+{
+    /*
+     * Reset peer address so the first send starts in the requester state
+     * rather than reusing leftover state from a previous session.
+     */
+    m_mctp_recv_addr_valid = false;
+    spdm_emu_io_ops_register(&mctp_kernel_io_ops);
+}

--- a/spdm_emu/spdm_emu_common/spdm_emu_mctp_kernel.h
+++ b/spdm_emu/spdm_emu_common/spdm_emu_mctp_kernel.h
@@ -1,0 +1,26 @@
+/**
+ *  Copyright Notice:
+ *  Copyright 2021-2026 DMTF. All rights reserved.
+ *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/spdm-emu/blob/main/LICENSE.md
+ **/
+
+#ifndef __SPDM_EMU_MCTP_KERNEL_H__
+#define __SPDM_EMU_MCTP_KERNEL_H__
+
+/**
+ * Register the Linux kernel AF_MCTP IO ops and reset the peer address state.
+ *
+ * Call once each time an AF_MCTP socket is opened — from
+ * init_mctp_kernel_client() (requester) and create_mctp_kernel_socket()
+ * (responder) — before any send/receive operation.
+ *
+ * On non-Linux platforms this is a no-op inline stub so callers need no
+ * compile-time guards.
+ */
+#ifdef __linux__
+void spdm_emu_mctp_kernel_register_io_ops(void);
+#else
+static inline void spdm_emu_mctp_kernel_register_io_ops(void) {}
+#endif
+
+#endif /* __SPDM_EMU_MCTP_KERNEL_H__ */

--- a/spdm_emu/spdm_requester_emu/CMakeLists.txt
+++ b/spdm_emu/spdm_requester_emu/CMakeLists.txt
@@ -33,6 +33,14 @@ set(src_spdm_requester_emu
     ${PROJECT_SOURCE_DIR}/spdm_emu/spdm_emu_common/support.c
 )
 
+# Linux kernel AF_MCTP socket transport is Linux-specific; only build it there.
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    list(APPEND src_spdm_requester_emu
+        spdm_requester_linux_mctp.c
+        ${PROJECT_SOURCE_DIR}/spdm_emu/spdm_emu_common/spdm_emu_mctp_kernel.c
+    )
+endif()
+
 if (USE_SYSTEM_LIBSPDM)
   message("LIBSPDM_LIBRARIES: ${LIBSPDM_LIBRARIES}")
   add_executable(spdm_requester_emu ${src_spdm_requester_emu})

--- a/spdm_emu/spdm_requester_emu/spdm_requester_emu.c
+++ b/spdm_emu/spdm_requester_emu/spdm_requester_emu.c
@@ -1,6 +1,6 @@
 /**
  *  Copyright Notice:
- *  Copyright 2021-2025 DMTF. All rights reserved.
+ *  Copyright 2021-2026 DMTF. All rights reserved.
  *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/spdm-emu/blob/main/LICENSE.md
  **/
 
@@ -76,6 +76,15 @@ bool platform_client_routine(uint16_t port_number)
 
         EMU_LOG("Continuing with SPDM flow...\n");
     }
+    else if (m_use_transport_layer == SOCKET_TRANSPORT_TYPE_MCTP_LINUX_KERNEL) {
+        result = init_mctp_kernel_client(&platform_socket);
+        if (!result) {
+            socket_cleanup();
+            return false;
+        }
+
+        m_socket = platform_socket;
+    }
     else {
         result = init_client(&platform_socket, port_number);
         if (!result) {
@@ -87,10 +96,7 @@ bool platform_client_routine(uint16_t port_number)
     }
 
     if (m_use_transport_layer != SOCKET_TRANSPORT_TYPE_NONE
-#ifndef _MSC_VER
-        && m_use_transport_layer != SOCKET_TRANSPORT_TYPE_MCTP_LINUX_KERNEL
-#endif
-       ) {
+        && m_use_transport_layer != SOCKET_TRANSPORT_TYPE_MCTP_LINUX_KERNEL) {
         response_size = sizeof(m_receive_buffer);
         result = communicate_platform_data(
             m_socket,
@@ -253,17 +259,13 @@ bool platform_client_routine(uint16_t port_number)
     result = true;
 done:
     response_size = 0;
-#ifndef _MSC_VER
     if (m_use_transport_layer != SOCKET_TRANSPORT_TYPE_MCTP_LINUX_KERNEL) {
-#endif
         if (!communicate_platform_data(
                 m_socket, SOCKET_SPDM_COMMAND_SHUTDOWN - m_exe_mode,
                 NULL, 0, &response, &response_size, NULL)) {
             return false;
         }
-#ifndef _MSC_VER
     }
-#endif
 
     if (m_spdm_context != NULL) {
 #if LIBSPDM_FIPS_MODE

--- a/spdm_emu/spdm_requester_emu/spdm_requester_emu.c
+++ b/spdm_emu/spdm_requester_emu/spdm_requester_emu.c
@@ -86,7 +86,11 @@ bool platform_client_routine(uint16_t port_number)
         m_socket = platform_socket;
     }
 
-    if (m_use_transport_layer != SOCKET_TRANSPORT_TYPE_NONE) {
+    if (m_use_transport_layer != SOCKET_TRANSPORT_TYPE_NONE
+#ifndef _MSC_VER
+        && m_use_transport_layer != SOCKET_TRANSPORT_TYPE_MCTP_LINUX_KERNEL
+#endif
+       ) {
         response_size = sizeof(m_receive_buffer);
         result = communicate_platform_data(
             m_socket,
@@ -249,11 +253,17 @@ bool platform_client_routine(uint16_t port_number)
     result = true;
 done:
     response_size = 0;
-    if (!communicate_platform_data(
-            m_socket, SOCKET_SPDM_COMMAND_SHUTDOWN - m_exe_mode,
-            NULL, 0, &response, &response_size, NULL)) {
+#ifndef _MSC_VER
+    if (m_use_transport_layer != SOCKET_TRANSPORT_TYPE_MCTP_LINUX_KERNEL) {
+#endif
+        if (!communicate_platform_data(
+                m_socket, SOCKET_SPDM_COMMAND_SHUTDOWN - m_exe_mode,
+                NULL, 0, &response, &response_size, NULL)) {
             return false;
         }
+#ifndef _MSC_VER
+    }
+#endif
 
     if (m_spdm_context != NULL) {
 #if LIBSPDM_FIPS_MODE

--- a/spdm_emu/spdm_requester_emu/spdm_requester_emu.h
+++ b/spdm_emu/spdm_requester_emu/spdm_requester_emu.h
@@ -1,6 +1,6 @@
 /**
  *  Copyright Notice:
- *  Copyright 2021-2025 DMTF. All rights reserved.
+ *  Copyright 2021-2026 DMTF. All rights reserved.
  *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/spdm-emu/blob/main/LICENSE.md
  **/
 
@@ -27,5 +27,23 @@
 #include "spdm_emu.h"
 
 extern uint8_t m_other_slot_id;
+
+/**
+ * Create an AF_MCTP SOCK_DGRAM socket for the SPDM requester (Linux kernel
+ * MCTP stack).  See spdm_requester_linux_mctp.c for details.
+ *
+ * On non-Linux platforms this is a stub that reports the transport is
+ * unsupported, so call sites need no compile-time guard.
+ */
+#ifdef __linux__
+bool init_mctp_kernel_client(SOCKET *sock);
+#else
+static inline bool init_mctp_kernel_client(SOCKET *sock)
+{
+    (void)sock;
+    printf("MCTP_KERNEL transport is only supported on Linux.\n");
+    return false;
+}
+#endif
 
 #endif

--- a/spdm_emu/spdm_requester_emu/spdm_requester_linux_mctp.c
+++ b/spdm_emu/spdm_requester_emu/spdm_requester_linux_mctp.c
@@ -1,0 +1,55 @@
+/**
+ *  Copyright Notice:
+ *  Copyright 2021-2026 DMTF. All rights reserved.
+ *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/spdm-emu/blob/main/LICENSE.md
+ **/
+
+/**
+ * Linux kernel AF_MCTP socket creation for the SPDM requester.
+ *
+ * This file is only compiled on Linux (CMake if(UNIX)) so it contains no
+ * compile-time platform guards.
+ **/
+
+#include "spdm_requester_emu.h"
+#include "spdm_emu_mctp_kernel.h"
+
+#include <linux/mctp.h>
+#include <errno.h>
+
+/**
+ * Create an AF_MCTP SOCK_DGRAM socket for the SPDM requester.
+ *
+ * The requester does NOT call bind().  When sendto() is issued with
+ * MCTP_TAG_OWNER the kernel allocates a message tag and routes the
+ * corresponding response back to this socket automatically.  Binding here
+ * would compete with a concurrently running responder that has already
+ * bound the same (network, MCTP_ADDR_ANY, type) tuple and cause EADDRINUSE.
+ *
+ * m_use_eid must be a valid unicast EID (1-254, per DSP0236 §8.2).
+ **/
+bool init_mctp_kernel_client(SOCKET *sock)
+{
+    if (m_use_eid == 0) {
+        printf("MCTP_KERNEL transport requires a destination EID. "
+               "Use --eid <1-254>.\n");
+        return false;
+    }
+
+    SOCKET s = socket(AF_MCTP, SOCK_DGRAM, 0);
+    if (s == INVALID_SOCKET) {
+        printf("Create MCTP socket failed - %d\n", errno);
+        return false;
+    }
+
+    /*
+     * Register the kernel MCTP IO ops and reset any peer address state left
+     * over from a previous session so write starts in the requester state.
+     */
+    spdm_emu_mctp_kernel_register_io_ops();
+
+    printf("MCTP socket created (dst EID 0x%02x, net %u)\n",
+           m_use_eid, m_use_net);
+    *sock = s;
+    return true;
+}

--- a/spdm_emu/spdm_requester_emu/spdm_requester_spdm.c
+++ b/spdm_emu/spdm_requester_emu/spdm_requester_spdm.c
@@ -1,6 +1,6 @@
 /**
  *  Copyright Notice:
- *  Copyright 2021-2022 DMTF. All rights reserved.
+ *  Copyright 2021-2026 DMTF. All rights reserved.
  *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/spdm-emu/blob/main/LICENSE.md
  **/
 
@@ -184,10 +184,7 @@ void *spdm_client_init(void)
         max_spdm_msg_size = LIBSPDM_RECEIVER_BUFFER_SIZE - LIBSPDM_TRANSPORT_ADDITIONAL_SIZE;
     }
     if (m_use_transport_layer == SOCKET_TRANSPORT_TYPE_MCTP
-#ifndef _MSC_VER
-        || m_use_transport_layer == SOCKET_TRANSPORT_TYPE_MCTP_LINUX_KERNEL
-#endif
-       ) {
+        || m_use_transport_layer == SOCKET_TRANSPORT_TYPE_MCTP_LINUX_KERNEL) {
         libspdm_register_transport_layer_func(
             spdm_context,
             max_spdm_msg_size,

--- a/spdm_emu/spdm_requester_emu/spdm_requester_spdm.c
+++ b/spdm_emu/spdm_requester_emu/spdm_requester_spdm.c
@@ -183,7 +183,11 @@ void *spdm_client_init(void)
     if ((m_use_requester_capability_flags & SPDM_GET_CAPABILITIES_REQUEST_FLAGS_CHUNK_CAP) == 0) {
         max_spdm_msg_size = LIBSPDM_RECEIVER_BUFFER_SIZE - LIBSPDM_TRANSPORT_ADDITIONAL_SIZE;
     }
-    if (m_use_transport_layer == SOCKET_TRANSPORT_TYPE_MCTP) {
+    if (m_use_transport_layer == SOCKET_TRANSPORT_TYPE_MCTP
+#ifndef _MSC_VER
+        || m_use_transport_layer == SOCKET_TRANSPORT_TYPE_MCTP_LINUX_KERNEL
+#endif
+       ) {
         libspdm_register_transport_layer_func(
             spdm_context,
             max_spdm_msg_size,

--- a/spdm_emu/spdm_responder_emu/CMakeLists.txt
+++ b/spdm_emu/spdm_responder_emu/CMakeLists.txt
@@ -29,6 +29,14 @@ set(src_spdm_responder_emu
     ${PROJECT_SOURCE_DIR}/spdm_emu/spdm_emu_common/support.c
 )
 
+# Linux kernel AF_MCTP socket transport is Linux-specific; only build it there.
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    list(APPEND src_spdm_responder_emu
+        spdm_responder_linux_mctp.c
+        ${PROJECT_SOURCE_DIR}/spdm_emu/spdm_emu_common/spdm_emu_mctp_kernel.c
+    )
+endif()
+
 if (USE_SYSTEM_LIBSPDM)
   message("LIBSPDM_LIBRARIES: ${LIBSPDM_LIBRARIES}")
   add_executable(spdm_responder_emu ${src_spdm_responder_emu})

--- a/spdm_emu/spdm_responder_emu/spdm_responder_emu.c
+++ b/spdm_emu/spdm_responder_emu/spdm_responder_emu.c
@@ -1,6 +1,6 @@
 /**
  *  Copyright Notice:
- *  Copyright 2021-2025 DMTF. All rights reserved.
+ *  Copyright 2021-2026 DMTF. All rights reserved.
  *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/spdm-emu/blob/main/LICENSE.md
  **/
 
@@ -222,7 +222,6 @@ bool platform_server_routine(uint16_t port_number)
         }
         m_server_socket = responder_socket;
     }
-#ifndef _MSC_VER
     else if (m_use_transport_layer == SOCKET_TRANSPORT_TYPE_MCTP_LINUX_KERNEL) {
         /*
          * The Linux kernel MCTP stack uses SOCK_DGRAM - there is no listen()
@@ -241,7 +240,6 @@ bool platform_server_routine(uint16_t port_number)
         closesocket(m_server_socket);
         return true;
     }
-#endif
     else {
         result = create_socket(port_number, &responder_socket);
         if (!result) {

--- a/spdm_emu/spdm_responder_emu/spdm_responder_emu.c
+++ b/spdm_emu/spdm_responder_emu/spdm_responder_emu.c
@@ -222,6 +222,26 @@ bool platform_server_routine(uint16_t port_number)
         }
         m_server_socket = responder_socket;
     }
+#ifndef _MSC_VER
+    else if (m_use_transport_layer == SOCKET_TRANSPORT_TYPE_MCTP_LINUX_KERNEL) {
+        /*
+         * The Linux kernel MCTP stack uses SOCK_DGRAM - there is no listen()
+         * or accept().  Create a single bound socket and serve requests in a
+         * loop until the SPDM session ends or an error occurs.
+         */
+        result = create_mctp_kernel_socket(port_number, &responder_socket);
+        if (!result) {
+            EMU_ERR("Create MCTP kernel socket fail\n");
+            return false;
+        }
+        m_server_socket = responder_socket;
+        do {
+            continue_serving = platform_server(m_server_socket);
+        } while (continue_serving);
+        closesocket(m_server_socket);
+        return true;
+    }
+#endif
     else {
         result = create_socket(port_number, &responder_socket);
         if (!result) {

--- a/spdm_emu/spdm_responder_emu/spdm_responder_emu.h
+++ b/spdm_emu/spdm_responder_emu/spdm_responder_emu.h
@@ -1,6 +1,6 @@
 /**
  *  Copyright Notice:
- *  Copyright 2021-2025 DMTF. All rights reserved.
+ *  Copyright 2021-2026 DMTF. All rights reserved.
  *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/spdm-emu/blob/main/LICENSE.md
  **/
 
@@ -25,5 +25,24 @@
 #include "os_include.h"
 #include <stdio.h>
 #include "spdm_emu.h"
+
+/**
+ * Create and bind an AF_MCTP SOCK_DGRAM socket for the SPDM responder (Linux
+ * kernel MCTP stack).  See spdm_responder_linux_mctp.c for details.
+ *
+ * On non-Linux platforms this is a stub that reports the transport is
+ * unsupported, so call sites need no compile-time guard.
+ */
+#ifdef __linux__
+bool create_mctp_kernel_socket(uint16_t port_number, SOCKET *mctp_socket);
+#else
+static inline bool create_mctp_kernel_socket(uint16_t port_number, SOCKET *mctp_socket)
+{
+    (void)port_number;
+    (void)mctp_socket;
+    printf("MCTP_KERNEL transport is only supported on Linux.\n");
+    return false;
+}
+#endif
 
 #endif

--- a/spdm_emu/spdm_responder_emu/spdm_responder_linux_mctp.c
+++ b/spdm_emu/spdm_responder_emu/spdm_responder_linux_mctp.c
@@ -1,0 +1,68 @@
+/**
+ *  Copyright Notice:
+ *  Copyright 2021-2026 DMTF. All rights reserved.
+ *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/spdm-emu/blob/main/LICENSE.md
+ **/
+
+/**
+ * Linux kernel AF_MCTP socket creation for the SPDM responder.
+ *
+ * This file is only compiled on Linux (CMake if(UNIX)) so it contains no
+ * compile-time platform guards.
+ **/
+
+#include "spdm_responder_emu.h"
+#include "spdm_emu_mctp_kernel.h"
+
+#include <linux/mctp.h>
+#include <errno.h>
+#include <string.h>
+
+/**
+ * Create and bind an AF_MCTP SOCK_DGRAM socket for the SPDM responder.
+ *
+ * The socket is bound to (m_use_net, MCTP_ADDR_ANY, MCTP_MESSAGE_TYPE_SPDM)
+ * so it receives all incoming SPDM messages regardless of the local EID.
+ * Binding to MCTP_ADDR_ANY avoids requiring a specific EID to be assigned
+ * to a local interface by the MCTP daemon.
+ *
+ * If m_use_net is MCTP_NET_ANY (0) the kernel selects the network
+ * automatically when only one network is present.
+ *
+ * The port_number parameter is ignored (MCTP has no port concept); it is
+ * accepted for signature compatibility with create_socket().
+ **/
+bool create_mctp_kernel_socket(uint16_t port_number, SOCKET *mctp_socket)
+{
+    (void)port_number;
+
+    SOCKET s = socket(AF_MCTP, SOCK_DGRAM, 0);
+    if (s == INVALID_SOCKET) {
+        printf("Create MCTP socket failed - %d\n", errno);
+        return false;
+    }
+
+    struct sockaddr_mctp addr = { 0 };
+    addr.smctp_family       = AF_MCTP;
+    addr.smctp_network      = m_use_net;
+    addr.smctp_addr.s_addr  = MCTP_ADDR_ANY;
+    addr.smctp_type         = MCTP_MESSAGE_TYPE_SPDM;
+
+    int rc = bind(s, (struct sockaddr *)&addr, sizeof(addr));
+    if (rc == -1) {
+        printf("MCTP bind failed - %s\n", strerror(errno));
+        closesocket(s);
+        return false;
+    }
+
+    /*
+     * Register the kernel MCTP IO ops and reset any peer address state left
+     * over from a previous session.
+     */
+    spdm_emu_mctp_kernel_register_io_ops();
+
+    printf("MCTP responder socket bound (net %u, type 0x%02x)\n",
+           m_use_net, MCTP_MESSAGE_TYPE_SPDM);
+    *mctp_socket = s;
+    return true;
+}

--- a/spdm_emu/spdm_responder_emu/spdm_responder_spdm.c
+++ b/spdm_emu/spdm_responder_emu/spdm_responder_spdm.c
@@ -179,10 +179,7 @@ void *spdm_server_init(void)
         max_spdm_msg_size = LIBSPDM_RECEIVER_BUFFER_SIZE - LIBSPDM_TRANSPORT_ADDITIONAL_SIZE;
     }
     if (m_use_transport_layer == SOCKET_TRANSPORT_TYPE_MCTP
-#ifndef _MSC_VER
-        || m_use_transport_layer == SOCKET_TRANSPORT_TYPE_MCTP_LINUX_KERNEL
-#endif
-       ) {
+        || m_use_transport_layer == SOCKET_TRANSPORT_TYPE_MCTP_LINUX_KERNEL) {
         libspdm_register_transport_layer_func(
             spdm_context,
             max_spdm_msg_size,

--- a/spdm_emu/spdm_responder_emu/spdm_responder_spdm.c
+++ b/spdm_emu/spdm_responder_emu/spdm_responder_spdm.c
@@ -178,7 +178,11 @@ void *spdm_server_init(void)
     if ((m_use_responder_capability_flags & SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CHUNK_CAP) == 0) {
         max_spdm_msg_size = LIBSPDM_RECEIVER_BUFFER_SIZE - LIBSPDM_TRANSPORT_ADDITIONAL_SIZE;
     }
-    if (m_use_transport_layer == SOCKET_TRANSPORT_TYPE_MCTP) {
+    if (m_use_transport_layer == SOCKET_TRANSPORT_TYPE_MCTP
+#ifndef _MSC_VER
+        || m_use_transport_layer == SOCKET_TRANSPORT_TYPE_MCTP_LINUX_KERNEL
+#endif
+       ) {
         libspdm_register_transport_layer_func(
             spdm_context,
             max_spdm_msg_size,


### PR DESCRIPTION
My Proposal for issues #211 , and #336.
Assisted-by: GitHub Copilot CLI 1.0.65:Claude Sonnet 4.6
Assisted-by: GitHub Copilot CLI 1.0.71:Claude Sonnet 5

@wmaroneAMD 
The first commit is coming from your PR with my review and enhancement for #463 .
https://github.com/DMTF/spdm-emu/pull/510/changes/bd11cbd7e2d333918205c0ae7a9f6c437a9ead8b

I kept the original history of development with AI assistance and my review.
And then considered the name convension of original code, and option , edge cases for the unpredicted  packet order during the period of MCTP transport and finally refactored the solution with abstraction and overrides because the support is not generic but Linux kernel only. 

Done end-to-end testing on my native Ubuntu 24.04 system.
I have reviewed whole codes several times, the partial test-case design and result, picked 2 most important test case of SPDM-packet transport via Linux MCTP socket, manually executed test case myself.

I would probably not only make some enhancements and fix defects when review the codes in different perspectives in few weeks,
But also check everything working as usual as expected on Windows additionally.

MCTP Kernel Test Environment — Setup, Test Execution, Teardown

1. Prerequisites (one-time, per machine)

Kernel already includes MCTP support on Ubuntu 24.04 (6.x kernel).

Ubuntu 24.04 desktop version
Kernel 6.17.0-40-generic

`grep MCTP /boot/config-$(uname -r)`

CONFIG_MCTP=y
CONFIG_MCTP_FLOWS=y
\# MCTP Device Drivers
CONFIG_MCTP_SERIAL=m
CONFIG_MCTP_TRANSPORT_I2C=m
CONFIG_MCTP_TRANSPORT_I3C=m
CONFIG_MCTP_TRANSPORT_USB=m
\# end of MCTP Device Drivers

\# Load the serial-transport driver (creates a virtual MCTP link over a tty):
sudo modprobe mctp-serial
lsmod | grep mctp       \# confirm mctp_serial + mctp core loaded

\# Tools needed:
sudo apt install socat   \# to create a virtual serial-port pair (PTY loopback cable)
which ldattach           \# part of util-linux, sets the N_MCTP line discipline (usually preinstalled)

Note: this Ubuntu 24.04's  iproute2 6.1.0  build does not include the  ip mctp  subcommand ( Object "mctp" is unknown ), so address/route configuration is done with small Python scripts issuing raw  AF_NETLINK / NETLINK_ROUTE  messages directly ( RTM_NEWADDR / RTM_NEWROUTE  with  AF_MCTP=45 ), instead of the normal  ip mctp addr add  /  ip mctp route add  commands documented upstream.

2. Step-by-step environment setup

Step 1 — Create a virtual serial "cable" (loopback):

socat PTY,link=/tmp/mctp-pty0,raw,echo=0 PTY,link=/tmp/mctp-pty1,raw,echo=0 &

This creates two linked pseudo-terminals ( /tmp/mctp-pty0  ↔  /tmp/mctp-pty1 ) that behave like a null-modem cable — anything written to one appears on the other.

Step 2 — Attach the MCTP line discipline to each end:

sudo ldattach 28 /dev/pts/N0   \# N_MCTP discipline (28) on pty0 → creates mctpserial0
sudo ldattach 28 /dev/pts/N1   \# same on pty1 → creates mctpserial1

Each  ldattach  call turns its tty into a new  mctpserialX  network interface (visible in  ip link ).

Step 3 — Isolate the two "nodes" in separate network namespaces:

sudo ip netns add mctp_resp
sudo ip link set mctpserial1 netns mctp_resp  \# responder side moves into its own namespace
\# mctpserial0 stays in the default/root namespace (acts as the requester side)
sudo ip link set mctpserial0 up
sudo ip netns exec mctp_resp ip link set mctpserial1 up

Step 4 — Assign MCTP endpoint IDs (EIDs) and routes (via the raw-netlink Python helper, since  ip mctp  isn't available):

sudo python3 [mctp_fullsetup.py](https://github.com/user-attachments/files/30180258/mctp_fullsetup.py)

This script:

• Finds  mctpserial0 's interface index.
• Deletes/recreates the  mctp_resp  namespace and moves  mctpserial1  into it.
• In the root namespace: assigns local EID 20 to  mctpserial0 , adds a route so EID 10 is reachable via  mctpserial0 .
• In the  mctp_resp  namespace: assigns local EID 10 to  mctpserial1 , adds a route so EID 20 is reachable via  mctpserial1 .

Verify:

ip addr show mctpserial0                       \# expect: family 45 (MCTP), UP
sudo ip netns exec mctp_resp ip addr show mctpserial1

Grant the binaries raw-socket capability (needed since AF_MCTP sockets require  CAP_NET_RAW , and we don't want to run everything as root):

sudo setcap cap_net_raw+ep build/bin/spdm_requester_emu
sudo setcap cap_net_raw+ep build/bin/spdm_responder_emu

⚠️ This capability is a file attribute — it's lost every time the binary is rebuilt and must be reapplied.

3. Running each regression test case

Clean stale artifacts first (a leftover  slot_id_0_cert_chain.der  from earlier  SET_CERTIFICATE  tests causes spurious failures):

rm -f build/bin/slot_id_0_cert_chain.der

TC-01 / TC-02 — CLI validation ( --eid ,  --net  range checks):

cd build/bin
./spdm_responder_emu --trans MCTP_KERNEL --eid 0     \# expect: rejected
./spdm_responder_emu --trans MCTP_KERNEL --eid 300    \# expect: rejected
./spdm_responder_emu --trans MCTP_KERNEL --eid 20 --net 99  \ # expect: parses (validated separately)

TC-04/TC-05 — MCTP_KERNEL full SPDM flow (the new code path):

\# Terminal / background job 1 — responder inside its namespace, listening as EID 10:
sudo ip netns exec mctp_resp ./spdm_responder_emu --trans MCTP_KERNEL

\# Terminal / background job 2 — requester in root namespace, targeting EID 10:
./spdm_requester_emu --trans MCTP_KERNEL --eid 10

Passes when the log shows the full sequence:  GET_VERSION → GET_CAPABILITIES → NEGOTIATE_ALGORITHMS → GET_DIGESTS → GET_CERTIFICATE → CHALLENGE_AUTH → KEY_EXCHANGE → FINISH → HEARTBEAT → KEY_UPDATE → END_SESSION_ACK , and prints  Client stopped .

TC-06 — MCTP (TCP-emulated) transport, on its own port:

./spdm_responder_emu --trans MCTP --port 2323 &
timeout 300 ./spdm_requester_emu --trans MCTP --port 2323

TC-07 — PCI_DOE transport (use a distinct port to avoid clashing with TC-06):

./spdm_responder_emu --trans PCI_DOE --port 3333 &
timeout 300 ./spdm_requester_emu --trans PCI_DOE --port 3333

TC-08 — Plain TCP transport (again, distinct port):

./spdm_responder_emu --trans TCP --port 4444 &
timeout 300 ./spdm_requester_emu --trans TCP --port 4444

Each transport's flow includes a long GET_MEASUREMENTS index-enumeration loop (looping ~0x00–0xFF indices, mostly  SPDM_ERROR ) — this is expected/pre-existing and can take 2–4 minutes; a  timeout 300  is generous enough for it to finish cleanly on all transports.

Pass criteria for TC-06/07/08: log ends with  SPDM_END_SESSION_ACK  and  Client stopped .

4. Teardown

\# Kill any lingering requester/responder processes:
pgrep -af spdm_responder_emu; pgrep -af spdm_requester_emu
sudo kill <pid> <pid> ...

\# Remove the responder network namespace and interfaces:
sudo ip netns del mctp_resp
sudo ip link delete mctpserial0 2>/dev/null   # or just let ldattach's parent exit remove it

\# Stop the socat PTY pair and ldattach processes:
pgrep -af "socat PTY"; pgrep -af ldattach
sudo kill <pid> <pid> ...

\# Clean stray test artifacts:
rm -f build/bin/slot_id_0_cert_chain.der /tmp/mctp-pty0 /tmp/mctp-pty1

\# If a temporary passwordless-sudo rule was added for this test session, remove it:
sudo rm -f /etc/sudoers.d/agent-name-temp

\# Optionally unload the driver:
sudo rmmod mctp_serial

5. Latest Regression Test Results (post-refactor validation)
│ TC-01 │ --eid range validation (0/255/300 rejected)                                                       
│ TC-02 │ --net validation
│ TC-04 │ MCTP_KERNEL — SPDM auth handshake (GET_VERSION → CHALLENGE_AUTH)                                                            
│ TC-05 │ MCTP_KERNEL — session establishment (KEY_EXCHANGE, FINISH, HEARTBEAT, ...etc)                                                       
│ TC-06 │ MCTP (TCP-emulated) — full regression
│ TC-07 │ PCI_DOE — full regression
│ TC-08 │ TCP — full regression

Thanks for your reading.
Please feel me and leave your comment below.

Best Regards, 
Leon Lin

