### PR TITLE
Line buffer stdout so traces are not delayed when piped

### DIFF
--- a/spdm_emu/spdm_requester_emu/spdm_requester_emu.c
+++ b/spdm_emu/spdm_requester_emu/spdm_requester_emu.c
@@ -294,6 +294,16 @@ done:
 int main(int argc, char *argv[])
 {
     bool result;
+
+#ifndef _MSC_VER
+    /* Traces go to stdout, which glibc buffers when it is not a tty (for
+     * example a systemd service piping into journald). Line buffer it so traces
+     * appear as they are emitted. This must happen before any other operation
+     * on stdout. The Microsoft CRT has no line buffered mode and rejects a zero
+     * size for buffered modes, so leave Windows on the CRT default. */
+    setvbuf(stdout, NULL, _IOLBF, 0);
+#endif
+
     srand((unsigned int)time(NULL));
 
     process_args("spdm_requester_emu", argc, argv);

--- a/spdm_emu/spdm_responder_emu/spdm_responder_emu.c
+++ b/spdm_emu/spdm_responder_emu/spdm_responder_emu.c
@@ -280,6 +280,15 @@ int main(int argc, char *argv[])
     libspdm_return_t status;
     bool result;
 
+#ifndef _MSC_VER
+    /* Traces go to stdout, which glibc buffers when it is not a tty (for
+     * example a systemd service piping into journald). Line buffer it so traces
+     * appear as they are emitted. This must happen before any other operation
+     * on stdout. The Microsoft CRT has no line buffered mode and rejects a zero
+     * size for buffered modes, so leave Windows on the CRT default. */
+    setvbuf(stdout, NULL, _IOLBF, 0);
+#endif
+
     srand((unsigned int)time(NULL));
 
     process_args("spdm_responder_emu", argc, argv);


### PR DESCRIPTION
All emulator traces (`EMU_LOG`/`EMU_INFO`) and libspdm's own `LIBSPDM_DEBUG` output go to stdout via printf. glibc selects full buffering whenever stdout is not a tty, which is the case when `spdm_responder_emu` runs as a systemd service with its output piped into journald.

Because the responder then sits in `platform_server_routine()` for the lifetime of the process, that buffer only drains once it fills or the process exits, so `-v` traces reach the journal very late and in bursts. `EMU_ERR` is unaffected since stderr is unbuffered, which is why errors appeared immediately while traces did not.

Switch stdout to line buffering at the top of main() in both emulators, before process_args() performs any output, as setvbuf requires. `_IOLBF` rather than `_IONBF`: libspdm's debug printing emits hex dumps in small fragments, and unbuffered output would turn each fragment into its own write() syscall.